### PR TITLE
resin-supervisor-disk: Fix repository grep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Workaround for "docker images" behavior - https://bugzilla.redhat.com/show_bug.cgi?id=1312934 [Florin]
 * Have device registration provided by supervisor in resin-image and resin-device-register in resin-image-flasher [Andrei]
 * Include crda in resin images [Andrei]
 * Add support for hid-multitouch - available as kernel module [Andrei]

--- a/meta-resin-common/recipes-support/resin-supervisor/resin-supervisor-disk.bb
+++ b/meta-resin-common/recipes-support/resin-supervisor/resin-supervisor-disk.bb
@@ -110,7 +110,9 @@ python () {
         pull_output = subprocess.Popen(pull_cmd, shell=True, stdout=subprocess.PIPE).communicate()[0]
 
     # Inspect for fetching the version only if image exists
-    imagechk_cmd = "docker images %s | grep %s" % (target_repository, tag_repository)
+    # on Fedora 23 at least, docker has suffered slight changes (https://bugzilla.redhat.com/show_bug.cgi?id=1312934)
+    # hence we need the following workaround until the above bug is fixed:
+    imagechk_cmd = "docker images | grep '^\S*%s\s*%s'" % (target_repository, tag_repository)
     imagechk_output = subprocess.Popen(imagechk_cmd, shell=True, stdout=subprocess.PIPE).communicate()[0]
     if imagechk_output == "":
         bb.fatal("resin-supervisor-disk: No local supervisor images found.")


### PR DESCRIPTION
Instead of doing "docker images [repository_name]" and then grep for what we are
interested in, we should just do a "docker images" and search through that output.

The issue we are trying to fix is that on different build Operating Systems, "docker images"
will prepend the string "docker.io" to this command's output so our current way we grep will
just return nothing.

fixes #14 

Signed-off-by: Florin Sarbu <florin@resin.io>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/resin-os/meta-resin/15)
<!-- Reviewable:end -->
