### PR TITLE
image_types_resin: mkfs.vfat expects -C file not to exist

### DIFF
--- a/meta-resin-common/classes/image_types_resin.bbclass
+++ b/meta-resin-common/classes/image_types_resin.bbclass
@@ -249,6 +249,7 @@ IMAGE_CMD_resin-sdcard () {
 
     # Create a vfat filesystem for config partition
     CONFIG_BLOCKS=$(LC_ALL=C parted -s ${RESIN_SDIMG} unit b print | awk '/ 5 / { print substr($4, 1, length($4 -1)) / 512 /2 }')
+    rm -rf ${WORKDIR}/config.img
     mkfs.vfat -n "${RESIN_CONFIG_FS_LABEL}" -S 512 -C ${WORKDIR}/config.img $CONFIG_BLOCKS
 
     # Label what is not labeled


### PR DESCRIPTION
Signed-off-by: Andrei Gherzan <andrei@resin.io>

@floion @telphan

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/resin-os/meta-resin/32)
<!-- Reviewable:end -->
