### PR TITLE
resin flasher - Move sdcard image to the flasher rootfs instead of the boot partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Move resin-image sdcard file in the rootfs instead of the boot partition [Florin]
 * Add compression mechanism for binaries, using upx [Theodor]
 * Switch to docker 1.10.3 [Theodor]
 * Remove deprecated mmcroot from flasher init script [Andrei]

--- a/meta-resin-common/recipes-core/images/resin-image-flasher.bb
+++ b/meta-resin-common/recipes-core/images/resin-image-flasher.bb
@@ -6,9 +6,6 @@ inherit image-resin
 # Each machine should append this with their specific configuration
 IMAGE_FSTYPES = ""
 
-# Make sure we have enough space in boot partition
-RESIN_BOOT_SPACE = "1638400"
-
 # Make sure you have the resin image ready
 IMAGE_DEPENDS_resin-sdcard_append = " resin-image:do_rootfs"
 
@@ -25,14 +22,22 @@ IMAGE_INSTALL_append = " \
 # Avoid useless space by not using any btrfs partition
 BTRFS_IMAGE = ""
 
+# We do not use a back-up rootfs partition for the flasher image, so just default to IMAGE_ROOTFS_ALIGNMENT size
+UPDATE_SIZE_ALIGNED = "${IMAGE_ROOTFS_ALIGNMENT}"
+
 # Avoid naming clash with resin image labels
 RESIN_BOOT_FS_LABEL = "flash-boot"
 RESIN_ROOT_FS_LABEL = "flash-root"
 RESIN_UPDATE_FS_LABEL = "flash-updt"
 RESIN_CONFIG_FS_LABEL = "flash-conf"
 
-# Put the resin image inside the boot partition
-RESIN_BOOT_PARTITION_FILES_append = " \
-    resin-logo.png:/splash/resin-logo.png \
-    resin-image-${MACHINE}.resin-sdcard: \
-    "
+# Put the resin logo, uEnv.txt files inside the boot partition
+RESIN_BOOT_PARTITION_FILES_append = " resin-logo.png:/splash/resin-logo.png"
+
+# Put resin-image in the flasher rootfs
+add_resin_image_to_flasher_rootfs() {
+    mkdir -p ${WORKDIR}/rootfs/opt
+    cp ${DEPLOY_DIR_IMAGE}/resin-image-${MACHINE}.resin-sdcard ${WORKDIR}/rootfs/opt
+}
+
+IMAGE_PREPROCESS_COMMAND += " add_resin_image_to_flasher_rootfs; "

--- a/meta-resin-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-resin-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -114,13 +114,13 @@ fi
 
 # Flash Resin image on internal device
 inform "Flash internal device... will take around 5 minutes... "
-dd if=$EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT/$RESIN_IMAGE of=/dev/$INTERNAL_DEVICE_KERNEL bs=4M 2> /tmp/dd_progress_log & DD_PID=$!
+dd if=/opt/$RESIN_IMAGE of=/dev/$INTERNAL_DEVICE_KERNEL bs=4M 2> /tmp/dd_progress_log & DD_PID=$!
 
 if ! kill -0 $DD_PID; then
     fail "Failed to flash internal device $INTERNAL_DEVICE_KERNEL."
 fi
 
-IMAGE_FILE_SIZE=`wc -c $EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT/$RESIN_IMAGE | awk '{print $1}'`
+IMAGE_FILE_SIZE=`wc -c /opt/$RESIN_IMAGE | awk '{print $1}'`
 
 resin-device-progress --percentage 0 --state "Starting flashing resin.io on internal media"
 


### PR DESCRIPTION
@agherzan @telphan 