### PR TITLE
Update resin-provisioner to 1.0.1

### DIFF
--- a/meta-resin-common/recipes-go/resin-provisioner/resin-provisioner_1.0.1.bb
+++ b/meta-resin-common/recipes-go/resin-provisioner/resin-provisioner_1.0.1.bb
@@ -2,19 +2,19 @@ DESCRIPTION = "Resin Provisioner"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${RESIN_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
-DEPENDS = "coreos-systemd-go-dbus gorilla-mux"
-
 SRC_URI = "git://github.com/resin-os/resin-provisioner;protocol=https;tag=v${PV};destsuffix=${PN}-${PV}/src/${GO_IMPORT}"
 
 inherit resin-go
 GO_IMPORT = "github.com/resin-os/resin-provisioner"
 
 inherit binary-compress
-FILES_COMPRESS = "${bindir}/provisioner-simple-client"
+FILES_COMPRESS = "${bindir}/resin-provision"
 
 do_install_append() {
     # We currently don't use the server binary
     rm -rf ${D}${bindir}/provisioner-server
+    # We also don't need the test simple client binary
+    rm -rf ${D}${bindir}/provisioner-simple-client
 }
 
 # There is a bash script in the sources


### PR DESCRIPTION
Binary to use is now called `resin-provision`. Dependencies are vendored, so no need to make this package depend on them.

Connects to #123 