### PR TITLE
kernel-modules-headers.bb: Allow do_patch

### DIFF
--- a/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
+++ b/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
@@ -18,8 +18,6 @@ B = "${WORKDIR}"
 
 inherit deploy
 
-do_patch[noexec] = "1"
-
 do_configure[noexec] = "1"
 
 do_compile() {


### PR DESCRIPTION
We need to allow do_patch to be able to take place as we patch the sources
from another location and this setting from here will prevent any patching
to take place.

Signed-off-by: Florin Sarbu <florin@resin.io>