### PR TITLE
resin-init-flasher: Don't error on "let" errors

### DIFF
--- a/meta-resin-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-resin-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -104,7 +104,7 @@ while kill -USR1 $DD_PID; do
         continue
     fi
     IMAGE_WRITTEN_BYTES=`cat /tmp/dd_progress_log | awk 'END{print $1}'`
-    let RATIO=$IMAGE_WRITTEN_BYTES*100/$IMAGE_FILE_SIZE
+    let RATIO=$IMAGE_WRITTEN_BYTES*100/$IMAGE_FILE_SIZE || true
     resin-device-progress --percentage $RATIO --state "Flashing resin.io on internal media" || true
     truncate -s 0 /tmp/dd_progress_log
 done


### PR DESCRIPTION
We use let to calculate the ratio of the provisioning progress. This will
error expectedly on first calculation(s) because "let" exits with an error if
arithmetic expression used is evaluated to 0. This happens when provisioning
progress is less than 1%.

Signed-off-by: Florin Sarbu <florin@resin.io>