### PR TITLE
docker.service: Fix key.json check

### DIFF
--- a/meta-resin-common/recipes-containers/docker/docker/docker.service
+++ b/meta-resin-common/recipes-containers/docker/docker/docker.service
@@ -7,7 +7,7 @@ Requires=docker.socket var-lib-docker.mount
 [Service]
 Type=notify
 Restart=always
-ExecStartPre=/bin/sh -c "/usr/bin/test -s /etc/docker/key.json || /bin/rm /etc/docker/key.json"
+ExecStartPre=/bin/sh -c "/usr/bin/test -s /etc/docker/key.json || /bin/rm -f /etc/docker/key.json"
 ExecStart=/usr/bin/docker daemon -s btrfs -H fd://
 #Adjust OOMscore to -900 to make killing docker unlikely
 OOMScoreAdjust=-900


### PR DESCRIPTION
We need to forcefully remove the file as at first boot this file will not
be available and the docker.service will fail to start because this ExecStartPre
will fail to non-forcefully remove a non-existent file.

Signed-off-by: Florin Sarbu <florin@resin.io>