### PR TITLE
Bump resin-supervisor to v1.12.0

### DIFF
--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
@@ -1,7 +1,7 @@
 require docker-disk.inc
 
 TARGET_REPOSITORY ?= "${SUPERVISOR_REPOSITORY}"
-TARGET_TAG ?= "v1.11.6"
+TARGET_TAG ?= "v1.12.0"
 LED_FILE ?= "/dev/null"
 
 inherit systemd


### PR DESCRIPTION
connects to #192
[Changelog](https://github.com/resin-io/resin-supervisor/blob/master/CHANGELOG.md):
* Add endpoints for docker-compose up and down [Pablo]