### PR TITLE
kernel-modules-headers.bb: Change the TRANSLATED_TARGET_ARCH to match all x86 machine types

### DIFF
--- a/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
+++ b/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
@@ -22,7 +22,7 @@ do_configure[noexec] = "1"
 
 do_compile() {
     mkdir -p kernel_modules_headers
-    if [ "${TRANSLATED_TARGET_ARCH}" = "x86-64" ] || [ "${TRANSLATED_TARGET_ARCH}" = "i686" ]; then
+    if echo ${TRANSLATED_TARGET_ARCH} | grep  -q -e "[ix].*86" ; then
         TGT_ARCH="x86"
     else
         TGT_ARCH=${TRANSLATED_TARGET_ARCH}


### PR DESCRIPTION
TRANSLATED_TARGET_ARCH now uses a regex to match all x86 types.
Connects to #152