### PR TITLE
resin-image: Generate fingerprints just before image creation

### DIFF
--- a/meta-resin-common/recipes-core/images/resin-image.bb
+++ b/meta-resin-common/recipes-core/images/resin-image.bb
@@ -43,7 +43,7 @@ generate_hostos_version () {
     echo "${HOSTOS_VERSION}" > ${DEPLOY_DIR_IMAGE}/VERSION_HOSTOS
 }
 
-ROOTFS_POSTPROCESS_COMMAND += " generate_rootfs_fingerprints ; "
+IMAGE_PREPROCESS_COMMAND += " generate_rootfs_fingerprints ; "
 IMAGE_POSTPROCESS_COMMAND += " generate_hostos_version ; "
 
 RESIN_BOOT_PARTITION_FILES_append = " resin-logo.png:/splash/resin-logo.png"


### PR DESCRIPTION
If we generate the fingerprints as a post rootfs, other functions might
change the rootfs in different ways (for example zap passwd). In this
case the fingerprints will depend on the order of this function and if
it is not the last one might include bad hashes. Moving this generation
before image create we ensure that all the other postrootfs functions
were finalized.

Signed-off-by: Andrei Gherzan <andrei@resin.io>

@floion @telphan 
