### PR TITLE
Bump resin-supervisor to v1.12.1

### DIFF
--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
@@ -1,7 +1,7 @@
 require docker-disk.inc
 
 TARGET_REPOSITORY ?= "${SUPERVISOR_REPOSITORY}"
-TARGET_TAG ?= "v1.12.0"
+TARGET_TAG ?= "v1.12.1"
 LED_FILE ?= "/dev/null"
 
 inherit systemd


### PR DESCRIPTION
connects  to #195 
[Changelog](https://github.com/resin-io/resin-supervisor/blob/master/CHANGELOG.md):
* Fix preloaded apps by passing appId to extendEnvVars
