### PR TITLE
docker: boltdb: correct broken unaligned load/store in armv5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Fix boltdb alignment issue for armv5 in docker, fixes docker 1.10.3 on armv5 devices [Lorenzo]
 * Include firmware for iwlwifi-8000C-13 - 6th generation Intel NUC [Andrei]
 * Disable DHCP server functionality from dnsmasq [Florin]
 * Update supervisor to v1.13.0 [Andrei]

--- a/meta-resin-common/recipes-containers/docker/docker/0001-bucket-correct-broken-unaligned-load-store-in-armv5.patch
+++ b/meta-resin-common/recipes-containers/docker/docker/0001-bucket-correct-broken-unaligned-load-store-in-armv5.patch
@@ -1,0 +1,149 @@
+From 494b0c6feb74a8a4783bc2cc6f0ff406dbec9973 Mon Sep 17 00:00:00 2001
+From: Lorenzo Stoakes <lstoakes@gmail.com>
+Date: Mon, 1 Aug 2016 13:40:27 +0100
+Subject: [PATCH] bucket: correct broken unaligned load/store in armv5
+
+armv5 devices and older (i.e. <= arm9 generation) require addresses that are
+stored to and loaded from to to be 4-byte aligned.
+
+If this is not the case the lower 2 bits of the address are cleared and the load
+is performed in an unexpected order, including up to 3 bytes of data located
+prior to the address.
+
+Inlined buckets are stored after their key in a page and since there is no
+guarantee that the key will be of a length that is a multiple of 4, it is
+possible for unaligned load/stores to occur when they are cast back to bucket
+and page pointer types.
+
+The fix adds a new field to track whether the current architecture exhibits this
+issue, sets it on module load for ARM architectures, and then on bucket open, if
+this field is set and the address is unaligned, a byte-by-byte copy of the
+inlined bucket is performed.
+
+Ref: http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.faqs/ka15414.html
+
+Upstream-Status: Submitted https://github.com/boltdb/bolt/pull/578
+Signed-off-by: Lorenzo Stoakes <lstoakes@gmail.com>
+---
+ vendor/src/github.com/boltdb/bolt/bolt_386.go     |  3 +++
+ vendor/src/github.com/boltdb/bolt/bolt_amd64.go   |  3 +++
+ vendor/src/github.com/boltdb/bolt/bolt_arm.go     | 21 +++++++++++++++++++++
+ vendor/src/github.com/boltdb/bolt/bolt_arm64.go   |  3 +++
+ vendor/src/github.com/boltdb/bolt/bolt_ppc64le.go |  3 +++
+ vendor/src/github.com/boltdb/bolt/bolt_s390x.go   |  3 +++
+ vendor/src/github.com/boltdb/bolt/bucket.go       | 10 +++++++++-
+ 7 files changed, 45 insertions(+), 1 deletion(-)
+
+diff --git a/vendor/src/github.com/boltdb/bolt/bolt_386.go b/vendor/src/github.com/boltdb/bolt/bolt_386.go
+index e659bfb..820d533 100644
+--- a/vendor/src/github.com/boltdb/bolt/bolt_386.go
++++ b/vendor/src/github.com/boltdb/bolt/bolt_386.go
+@@ -5,3 +5,6 @@ const maxMapSize = 0x7FFFFFFF // 2GB
+
+ // maxAllocSize is the size used when creating array pointers.
+ const maxAllocSize = 0xFFFFFFF
++
++// Are unaligned load/stores broken on this arch?
++var brokenUnaligned = false
+diff --git a/vendor/src/github.com/boltdb/bolt/bolt_amd64.go b/vendor/src/github.com/boltdb/bolt/bolt_amd64.go
+index cca6b7e..98fafdb 100644
+--- a/vendor/src/github.com/boltdb/bolt/bolt_amd64.go
++++ b/vendor/src/github.com/boltdb/bolt/bolt_amd64.go
+@@ -5,3 +5,6 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
+
+ // maxAllocSize is the size used when creating array pointers.
+ const maxAllocSize = 0x7FFFFFFF
++
++// Are unaligned load/stores broken on this arch?
++var brokenUnaligned = false
+diff --git a/vendor/src/github.com/boltdb/bolt/bolt_arm.go b/vendor/src/github.com/boltdb/bolt/bolt_arm.go
+index e659bfb..7e5cb4b 100644
+--- a/vendor/src/github.com/boltdb/bolt/bolt_arm.go
++++ b/vendor/src/github.com/boltdb/bolt/bolt_arm.go
+@@ -1,7 +1,28 @@
+ package bolt
+
++import "unsafe"
++
+ // maxMapSize represents the largest mmap size supported by Bolt.
+ const maxMapSize = 0x7FFFFFFF // 2GB
+
+ // maxAllocSize is the size used when creating array pointers.
+ const maxAllocSize = 0xFFFFFFF
++
++// Are unaligned load/stores broken on this arch?
++var brokenUnaligned bool
++
++func init() {
++	// Simple check to see whether this arch handles unaligned load/stores
++	// correctly.
++
++	// ARM9 and older devices require load/stores to be from/to aligned
++	// addresses. If not, the lower 2 bits are cleared and that address is
++	// read in a jumbled up order.
++
++	// See http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.faqs/ka15414.html
++
++	raw := [6]byte{0xfe, 0xef, 0x11, 0x22, 0x22, 0x11}
++	val := *(*uint32)(unsafe.Pointer(uintptr(unsafe.Pointer(&raw)) + 2))
++
++	brokenUnaligned = val != 0x11222211
++}
+diff --git a/vendor/src/github.com/boltdb/bolt/bolt_arm64.go b/vendor/src/github.com/boltdb/bolt/bolt_arm64.go
+index 6d23093..b26d84f 100644
+--- a/vendor/src/github.com/boltdb/bolt/bolt_arm64.go
++++ b/vendor/src/github.com/boltdb/bolt/bolt_arm64.go
+@@ -7,3 +7,6 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
+
+ // maxAllocSize is the size used when creating array pointers.
+ const maxAllocSize = 0x7FFFFFFF
++
++// Are unaligned load/stores broken on this arch?
++var brokenUnaligned = false
+diff --git a/vendor/src/github.com/boltdb/bolt/bolt_ppc64le.go b/vendor/src/github.com/boltdb/bolt/bolt_ppc64le.go
+index 8351e12..8c143bc 100644
+--- a/vendor/src/github.com/boltdb/bolt/bolt_ppc64le.go
++++ b/vendor/src/github.com/boltdb/bolt/bolt_ppc64le.go
+@@ -7,3 +7,6 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
+
+ // maxAllocSize is the size used when creating array pointers.
+ const maxAllocSize = 0x7FFFFFFF
++
++// Are unaligned load/stores broken on this arch?
++var brokenUnaligned = false
+diff --git a/vendor/src/github.com/boltdb/bolt/bolt_s390x.go b/vendor/src/github.com/boltdb/bolt/bolt_s390x.go
+index f4dd26b..d7c39af 100644
+--- a/vendor/src/github.com/boltdb/bolt/bolt_s390x.go
++++ b/vendor/src/github.com/boltdb/bolt/bolt_s390x.go
+@@ -7,3 +7,6 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
+
+ // maxAllocSize is the size used when creating array pointers.
+ const maxAllocSize = 0x7FFFFFFF
++
++// Are unaligned load/stores broken on this arch?
++var brokenUnaligned = false
+diff --git a/vendor/src/github.com/boltdb/bolt/bucket.go b/vendor/src/github.com/boltdb/bolt/bucket.go
+index 2925288..e0e057d 100644
+--- a/vendor/src/github.com/boltdb/bolt/bucket.go
++++ b/vendor/src/github.com/boltdb/bolt/bucket.go
+@@ -130,9 +130,17 @@ func (b *Bucket) Bucket(name []byte) *Bucket {
+ func (b *Bucket) openBucket(value []byte) *Bucket {
+ 	var child = newBucket(b.tx)
+
++	// If unaligned load/stores are broken on this arch and value is
++	// unaligned simply clone to an aligned byte array.
++	unaligned := brokenUnaligned && uintptr(unsafe.Pointer(&value[0]))&3 != 0
++
++	if unaligned {
++		value = cloneBytes(value)
++	}
++
+ 	// If this is a writable transaction then we need to copy the bucket entry.
+ 	// Read-only transactions can point directly at the mmap entry.
+-	if b.tx.writable {
++	if b.tx.writable && !unaligned {
+ 		child.bucket = &bucket{}
+ 		*child.bucket = *(*bucket)(unsafe.Pointer(&value[0]))
+ 	} else {
+--
+2.9.0

--- a/meta-resin-common/recipes-containers/docker/docker_git.bb
+++ b/meta-resin-common/recipes-containers/docker/docker_git.bb
@@ -24,6 +24,7 @@ SRC_URI = "\
   git://github.com/docker/docker.git;branch=${SRCBRANCH};nobranch=1 \
   file://docker.service \
   file://var-lib-docker.mount \
+  file://0001-bucket-correct-broken-unaligned-load-store-in-armv5.patch \
 	"
 
 # Apache-2.0 for docker


### PR DESCRIPTION
Applies fix to boltdb to resolve issue with unaligned 64-bit access on armv5 platforms.

Idempotent for non-armv5 devices.

Fixes issue #227. See that issue (+ its links) for more details.