### PR TITLE
add and install linux-firmware-ibt and linux-firmware-iwlwifi-7265D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Include firmware for iwlwifi-7265D and ibt [Michal]
+
 # v1.8 - 2016-08-02
 
 * Fix plymouth output to tty1 [Theodor]

--- a/meta-resin-common/recipes-core/packagegroups/packagegroup-resin-connectivity.bb
+++ b/meta-resin-common/recipes-core/packagegroups/packagegroup-resin-connectivity.bb
@@ -12,6 +12,8 @@ CONNECTIVITY_MODULES = ""
 
 CONNECTIVITY_FIRMWARES ?= " \
     linux-firmware-ath9k \
+    linux-firmware-ibt \
+    linux-firmware-iwlwifi-7265D \
     linux-firmware-ralink \
     linux-firmware-rtl8192cu \
     "

--- a/meta-resin-common/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
+++ b/meta-resin-common/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
@@ -1,7 +1,18 @@
-PACKAGES =+ "${PN}-bcm43143 ${PN}-rtl8188eu"
+PACKAGES =+ "${PN}-bcm43143 ${PN}-ibt ${PN}-iwlwifi-7265D ${PN}-rtl8188eu"
 
 FILES_${PN}-bcm43143 = " \
     /lib/firmware/brcm/brcmfmac43143*.bin \
+    "
+
+FILES_${PN}-ibt = " \
+    /lib/firmware/intel/ibt-hw-37.8.bseq \
+    /lib/firmware/intel/ibt-hw-37.8.10-fw-1.10.3.11.e.bseq \
+    "
+
+FILES_${PN}-iwlwifi-7265D = " \
+    /lib/firmware/iwlwifi-7265D-13.ucode \
+    /lib/firmware/iwlwifi-7265D-12.ucode \
+    /lib/firmware/iwlwifi-7265D-11.ucode \
     "
 
 FILES_${PN}-rtl8188eu = " \


### PR DESCRIPTION
fixes https://github.com/resin-os/resin-intel/issues/20 and
https://github.com/resin-os/resin-intel/issues/21