### PR TITLE
docker: fix STOPSIGNAL handling when set in a Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Backport STOPSIGNAL fix for docker [petrosagg]
 * Make Docker log to journald [Michal]
 
 # v1.10 - 2016-08-24

--- a/meta-resin-common/recipes-containers/docker/docker/0002-Inherit-StopSignal-from-Dockerfile.patch
+++ b/meta-resin-common/recipes-containers/docker/docker/0002-Inherit-StopSignal-from-Dockerfile.patch
@@ -1,0 +1,81 @@
+From a55a6a1a56c4387c73b79b28cd0d57c1243578c6 Mon Sep 17 00:00:00 2001
+From: David Calavera <david.calavera@gmail.com>
+Date: Fri, 12 Feb 2016 17:56:40 -0500
+Subject: [PATCH] Inherit StopSignal from Dockerfile.
+
+Make sure the image configuration is not overriden by the default
+value in the `create` flag.
+
+Signed-off-by: David Calavera <david.calavera@gmail.com>
+Upstream-Status: Backport
+Signed-off-by: Petros Angelatos <petrosagg@gmail.com>
+---
+ daemon/commit.go                         |  4 ++++
+ integration-cli/docker_cli_build_test.go | 14 +++++++++++---
+ runconfig/opts/parse.go                  |  4 +++-
+ 3 files changed, 18 insertions(+), 4 deletions(-)
+
+diff --git a/daemon/commit.go b/daemon/commit.go
+index d0c4924..3baee81 100644
+--- a/daemon/commit.go
++++ b/daemon/commit.go
+@@ -89,6 +89,10 @@ func merge(userConf, imageConf *containertypes.Config) error {
+ 			userConf.Volumes[k] = v
+ 		}
+ 	}
++
++	if userConf.StopSignal == "" {
++		userConf.StopSignal = imageConf.StopSignal
++	}
+ 	return nil
+ }
+ 
+diff --git a/integration-cli/docker_cli_build_test.go b/integration-cli/docker_cli_build_test.go
+index b5bd1d7..fe4d9e8 100644
+--- a/integration-cli/docker_cli_build_test.go
++++ b/integration-cli/docker_cli_build_test.go
+@@ -5891,15 +5891,23 @@ func (s *DockerSuite) TestBuildNullStringInAddCopyVolume(c *check.C) {
+ 
+ func (s *DockerSuite) TestBuildStopSignal(c *check.C) {
+ 	testRequires(c, DaemonIsLinux)
+-	name := "test_build_stop_signal"
+-	_, err := buildImage(name,
++	imgName := "test_build_stop_signal"
++	_, err := buildImage(imgName,
+ 		`FROM busybox
+ 		 STOPSIGNAL SIGKILL`,
+ 		true)
+ 	c.Assert(err, check.IsNil)
+-	res, err := inspectFieldJSON(name, "Config.StopSignal")
++	res, err := inspectFieldJSON(imgName, "Config.StopSignal")
+ 	c.Assert(err, check.IsNil)
++	if res != `"SIGKILL"` {
++		c.Fatalf("Signal %s, expected SIGKILL", res)
++	}
++
++	containerName := "test-container-stop-signal"
++	dockerCmd(c, "run", "-d", "--name", containerName, imgName, "top")
+ 
++	res, err = inspectFieldJSON(containerName, "Config.StopSignal")
++	c.Assert(err, check.IsNil)
+ 	if res != `"SIGKILL"` {
+ 		c.Fatalf("Signal %s, expected SIGKILL", res)
+ 	}
+diff --git a/runconfig/opts/parse.go b/runconfig/opts/parse.go
+index 41cb377..d05baed 100644
+--- a/runconfig/opts/parse.go
++++ b/runconfig/opts/parse.go
+@@ -375,7 +375,9 @@ func Parse(cmd *flag.FlagSet, args []string) (*container.Config, *container.Host
+ 		Entrypoint:      entrypoint,
+ 		WorkingDir:      *flWorkingDir,
+ 		Labels:          ConvertKVStringsToMap(labels),
+-		StopSignal:      *flStopSignal,
++	}
++	if cmd.IsSet("-stop-signal") {
++		config.StopSignal = *flStopSignal
+ 	}
+ 
+ 	hostConfig := &container.HostConfig{
+-- 
+2.9.3
+

--- a/meta-resin-common/recipes-containers/docker/docker_git.bb
+++ b/meta-resin-common/recipes-containers/docker/docker_git.bb
@@ -26,6 +26,7 @@ SRC_URI = "\
   file://var-lib-docker.mount \
   file://0001-bucket-correct-broken-unaligned-load-store-in-armv5.patch \
   file://journal.patch \
+  file://0002-Inherit-StopSignal-from-Dockerfile.patch \
 	"
 
 # Apache-2.0 for docker


### PR DESCRIPTION
fixes #270 
connects to resin-io-library/base-images#77
