### PR TITLE
resin-btrfs-balance: Fix btrfs balance options for mixed mode

### DIFF
--- a/meta-resin-common/recipes-support/resin-btrfs/resin-btrfs-balance/resin-btrfs-balance
+++ b/meta-resin-common/recipes-support/resin-btrfs/resin-btrfs-balance/resin-btrfs-balance
@@ -3,7 +3,7 @@
 MOUNT_POINT=/mnt/data
 
 for usage in 0 5 10 15 20; do
-    btrfs balance start -dusage=$usage $MOUNT_POINT
+    btrfs balance start -dusage=$usage -musage=$usage $MOUNT_POINT
     if [ $? -ne 0 ]; then # Print the following on btrfs balance failure
         echo "Btrfs balance failed while freeing $usage % full block groups"
         exit 1


### PR DESCRIPTION
We now use btrfs in mixed mode. In this mode, data and metadata are combined into
the same blocks and btrfs balance needs also the -musage filter to function correctly.

Signed-off-by: Florin Sarbu <florin@resin.io>