### PR TITLE
docker: backport transactional layer store fixes

### DIFF
--- a/meta-resin-common/recipes-containers/docker/docker/0003-Safer-file-io-for-configuration-files.patch
+++ b/meta-resin-common/recipes-containers/docker/docker/0003-Safer-file-io-for-configuration-files.patch
@@ -1,0 +1,306 @@
+From 2145475e76554348c36de5dd77d9675758b9fded Mon Sep 17 00:00:00 2001
+From: Tonis Tiigi <tonistiigi@gmail.com>
+Date: Wed, 20 Apr 2016 17:08:47 -0700
+Subject: [PATCH 3/5] Safer file io for configuration files
+
+Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
+Upstream-Status: Backport
+Signed-off-by: Petros Angelatos <petrosagg@gmail.com>
+---
+ container/container.go            |  5 +--
+ distribution/metadata/metadata.go |  8 ++---
+ image/fs.go                       | 15 ++------
+ migrate/v1/migratev1.go           |  8 ++---
+ pkg/ioutils/fswriters.go          | 75 +++++++++++++++++++++++++++++++++++++++
+ pkg/ioutils/fswriters_test.go     | 31 ++++++++++++++++
+ reference/store.go                | 15 ++------
+ 7 files changed, 119 insertions(+), 38 deletions(-)
+ create mode 100644 pkg/ioutils/fswriters.go
+ create mode 100644 pkg/ioutils/fswriters_test.go
+
+diff --git a/container/container.go b/container/container.go
+index ea083c5..d561194 100644
+--- a/container/container.go
++++ b/container/container.go
+@@ -19,6 +19,7 @@ import (
+ 	derr "github.com/docker/docker/errors"
+ 	"github.com/docker/docker/image"
+ 	"github.com/docker/docker/layer"
++	"github.com/docker/docker/pkg/ioutils"
+ 	"github.com/docker/docker/pkg/promise"
+ 	"github.com/docker/docker/pkg/signal"
+ 	"github.com/docker/docker/pkg/symlink"
+@@ -114,7 +115,7 @@ func (container *Container) ToDisk() error {
+ 		return err
+ 	}
+ 
+-	jsonSource, err := os.Create(pth)
++	jsonSource, err := ioutils.NewAtomicFileWriter(pth, 0666)
+ 	if err != nil {
+ 		return err
+ 	}
+@@ -174,7 +175,7 @@ func (container *Container) WriteHostConfig() error {
+ 		return err
+ 	}
+ 
+-	f, err := os.Create(pth)
++	f, err := ioutils.NewAtomicFileWriter(pth, 0666)
+ 	if err != nil {
+ 		return err
+ 	}
+diff --git a/distribution/metadata/metadata.go b/distribution/metadata/metadata.go
+index 9f744d4..05ba4f8 100644
+--- a/distribution/metadata/metadata.go
++++ b/distribution/metadata/metadata.go
+@@ -5,6 +5,8 @@ import (
+ 	"os"
+ 	"path/filepath"
+ 	"sync"
++
++	"github.com/docker/docker/pkg/ioutils"
+ )
+ 
+ // Store implements a K/V store for mapping distribution-related IDs
+@@ -56,14 +58,10 @@ func (store *FSMetadataStore) Set(namespace, key string, value []byte) error {
+ 	defer store.Unlock()
+ 
+ 	path := store.path(namespace, key)
+-	tempFilePath := path + ".tmp"
+ 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+ 		return err
+ 	}
+-	if err := ioutil.WriteFile(tempFilePath, value, 0644); err != nil {
+-		return err
+-	}
+-	return os.Rename(tempFilePath, path)
++	return ioutils.AtomicWriteFile(path, value, 0644)
+ }
+ 
+ // Delete removes data indexed by namespace and key. The data file named after
+diff --git a/image/fs.go b/image/fs.go
+index 72c9ab4..955e1b8 100644
+--- a/image/fs.go
++++ b/image/fs.go
+@@ -9,6 +9,7 @@ import (
+ 
+ 	"github.com/Sirupsen/logrus"
+ 	"github.com/docker/distribution/digest"
++	"github.com/docker/docker/pkg/ioutils"
+ )
+ 
+ // IDWalkFunc is function called by StoreBackend.Walk
+@@ -118,12 +119,7 @@ func (s *fs) Set(data []byte) (ID, error) {
+ 	}
+ 
+ 	id := ID(digest.FromBytes(data))
+-	filePath := s.contentFile(id)
+-	tempFilePath := s.contentFile(id) + ".tmp"
+-	if err := ioutil.WriteFile(tempFilePath, data, 0600); err != nil {
+-		return "", err
+-	}
+-	if err := os.Rename(tempFilePath, filePath); err != nil {
++	if err := ioutils.AtomicWriteFile(s.contentFile(id), data, 0600); err != nil {
+ 		return "", err
+ 	}
+ 
+@@ -156,12 +152,7 @@ func (s *fs) SetMetadata(id ID, key string, data []byte) error {
+ 	if err := os.MkdirAll(baseDir, 0700); err != nil {
+ 		return err
+ 	}
+-	filePath := filepath.Join(s.metadataDir(id), key)
+-	tempFilePath := filePath + ".tmp"
+-	if err := ioutil.WriteFile(tempFilePath, data, 0600); err != nil {
+-		return err
+-	}
+-	return os.Rename(tempFilePath, filePath)
++	return ioutils.AtomicWriteFile(filepath.Join(s.metadataDir(id), key), data, 0600)
+ }
+ 
+ // GetMetadata returns metadata for a given ID.
+diff --git a/migrate/v1/migratev1.go b/migrate/v1/migratev1.go
+index aa9d48c..3c0e550 100644
+--- a/migrate/v1/migratev1.go
++++ b/migrate/v1/migratev1.go
+@@ -19,6 +19,7 @@ import (
+ 	"github.com/docker/docker/image"
+ 	imagev1 "github.com/docker/docker/image/v1"
+ 	"github.com/docker/docker/layer"
++	"github.com/docker/docker/pkg/ioutils"
+ 	"github.com/docker/docker/reference"
+ )
+ 
+@@ -160,12 +161,7 @@ func calculateLayerChecksum(graphDir, id string, ls checksumCalculator) error {
+ 		return err
+ 	}
+ 
+-	tmpFile := filepath.Join(graphDir, id, migrationDiffIDFileName+".tmp")
+-	if err := ioutil.WriteFile(tmpFile, []byte(diffID), 0600); err != nil {
+-		return err
+-	}
+-
+-	if err := os.Rename(tmpFile, filepath.Join(graphDir, id, migrationDiffIDFileName)); err != nil {
++	if err := ioutils.AtomicWriteFile(filepath.Join(graphDir, id, migrationDiffIDFileName), []byte(diffID), 0600); err != nil {
+ 		return err
+ 	}
+ 
+diff --git a/pkg/ioutils/fswriters.go b/pkg/ioutils/fswriters.go
+new file mode 100644
+index 0000000..ca97670
+--- /dev/null
++++ b/pkg/ioutils/fswriters.go
+@@ -0,0 +1,75 @@
++package ioutils
++
++import (
++	"io"
++	"io/ioutil"
++	"os"
++	"path/filepath"
++)
++
++// NewAtomicFileWriter returns WriteCloser so that writing to it writes to a
++// temporary file and closing it atomically changes the temporary file to
++// destination path. Writing and closing concurrently is not allowed.
++func NewAtomicFileWriter(filename string, perm os.FileMode) (io.WriteCloser, error) {
++	f, err := ioutil.TempFile(filepath.Dir(filename), ".tmp-"+filepath.Base(filename))
++	if err != nil {
++		return nil, err
++	}
++	abspath, err := filepath.Abs(filename)
++	if err != nil {
++		return nil, err
++	}
++	return &atomicFileWriter{
++		f:  f,
++		fn: abspath,
++	}, nil
++}
++
++// AtomicWriteFile atomically writes data to a file named by filename.
++func AtomicWriteFile(filename string, data []byte, perm os.FileMode) error {
++	f, err := NewAtomicFileWriter(filename, perm)
++	if err != nil {
++		return err
++	}
++	n, err := f.Write(data)
++	if err == nil && n < len(data) {
++		err = io.ErrShortWrite
++	}
++	if err1 := f.Close(); err == nil {
++		err = err1
++	}
++	return err
++}
++
++type atomicFileWriter struct {
++	f        *os.File
++	fn       string
++	writeErr error
++}
++
++func (w *atomicFileWriter) Write(dt []byte) (int, error) {
++	n, err := w.f.Write(dt)
++	if err != nil {
++		w.writeErr = err
++	}
++	return n, err
++}
++
++func (w *atomicFileWriter) Close() (retErr error) {
++	defer func() {
++		if retErr != nil {
++			os.Remove(w.f.Name())
++		}
++	}()
++	if err := w.f.Sync(); err != nil {
++		w.f.Close()
++		return err
++	}
++	if err := w.f.Close(); err != nil {
++		return err
++	}
++	if w.writeErr == nil {
++		return os.Rename(w.f.Name(), w.fn)
++	}
++	return nil
++}
+diff --git a/pkg/ioutils/fswriters_test.go b/pkg/ioutils/fswriters_test.go
+new file mode 100644
+index 0000000..40717a5
+--- /dev/null
++++ b/pkg/ioutils/fswriters_test.go
+@@ -0,0 +1,31 @@
++package ioutils
++
++import (
++	"bytes"
++	"io/ioutil"
++	"os"
++	"path/filepath"
++	"testing"
++)
++
++func TestAtomicWriteToFile(t *testing.T) {
++	tmpDir, err := ioutil.TempDir("", "atomic-writers-test")
++	if err != nil {
++		t.Fatalf("Error when creating temporary directory: %s", err)
++	}
++	defer os.RemoveAll(tmpDir)
++
++	expected := []byte("barbaz")
++	if err := AtomicWriteFile(filepath.Join(tmpDir, "foo"), expected, 0600); err != nil {
++		t.Fatalf("Error writing to file: %v", err)
++	}
++
++	actual, err := ioutil.ReadFile(filepath.Join(tmpDir, "foo"))
++	if err != nil {
++		t.Fatalf("Error reading from file: %v", err)
++	}
++
++	if bytes.Compare(actual, expected) != 0 {
++		t.Fatalf("Data mismatch, expected %q, got %q", expected, actual)
++	}
++}
+diff --git a/reference/store.go b/reference/store.go
+index 91c5c2a..00a2a09 100644
+--- a/reference/store.go
++++ b/reference/store.go
+@@ -4,7 +4,6 @@ import (
+ 	"encoding/json"
+ 	"errors"
+ 	"fmt"
+-	"io/ioutil"
+ 	"os"
+ 	"path/filepath"
+ 	"sort"
+@@ -12,6 +11,7 @@ import (
+ 
+ 	"github.com/docker/distribution/digest"
+ 	"github.com/docker/docker/image"
++	"github.com/docker/docker/pkg/ioutils"
+ )
+ 
+ var (
+@@ -256,18 +256,7 @@ func (store *store) save() error {
+ 	if err != nil {
+ 		return err
+ 	}
+-
+-	tempFilePath := store.jsonPath + ".tmp"
+-
+-	if err := ioutil.WriteFile(tempFilePath, jsonData, 0600); err != nil {
+-		return err
+-	}
+-
+-	if err := os.Rename(tempFilePath, store.jsonPath); err != nil {
+-		return err
+-	}
+-
+-	return nil
++	return ioutils.AtomicWriteFile(store.jsonPath, jsonData, 0600)
+ }
+ 
+ func (store *store) reload() error {
+-- 
+2.9.3
+

--- a/meta-resin-common/recipes-containers/docker/docker/0004-Set-permission-on-atomic-file-write.patch
+++ b/meta-resin-common/recipes-containers/docker/docker/0004-Set-permission-on-atomic-file-write.patch
@@ -1,0 +1,102 @@
+From 9396db6a301ae4693d12b71c8353de390e82dd2f Mon Sep 17 00:00:00 2001
+From: Derek McGowan <derek@mcgstyle.net>
+Date: Wed, 29 Jun 2016 13:09:13 -0700
+Subject: [PATCH 4/5] Set permission on atomic file write
+
+Perform chmod before rename with the atomic file writer.
+Ensure writeErr is set on short write and file is removed on write error.
+
+Signed-off-by: Derek McGowan <derek@mcgstyle.net> (github: dmcgowan)
+Upstream-Status: Backport
+Signed-off-by: Petros Angelatos <petrosagg@gmail.com>
+---
+ pkg/ioutils/fswriters.go      | 13 ++++++++++---
+ pkg/ioutils/fswriters_test.go | 10 +++++++++-
+ 2 files changed, 19 insertions(+), 4 deletions(-)
+
+diff --git a/pkg/ioutils/fswriters.go b/pkg/ioutils/fswriters.go
+index ca97670..6dc50a0 100644
+--- a/pkg/ioutils/fswriters.go
++++ b/pkg/ioutils/fswriters.go
+@@ -15,13 +15,15 @@ func NewAtomicFileWriter(filename string, perm os.FileMode) (io.WriteCloser, err
+ 	if err != nil {
+ 		return nil, err
+ 	}
++
+ 	abspath, err := filepath.Abs(filename)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+ 	return &atomicFileWriter{
+-		f:  f,
+-		fn: abspath,
++		f:    f,
++		fn:   abspath,
++		perm: perm,
+ 	}, nil
+ }
+ 
+@@ -34,6 +36,7 @@ func AtomicWriteFile(filename string, data []byte, perm os.FileMode) error {
+ 	n, err := f.Write(data)
+ 	if err == nil && n < len(data) {
+ 		err = io.ErrShortWrite
++		f.(*atomicFileWriter).writeErr = err
+ 	}
+ 	if err1 := f.Close(); err == nil {
+ 		err = err1
+@@ -45,6 +48,7 @@ type atomicFileWriter struct {
+ 	f        *os.File
+ 	fn       string
+ 	writeErr error
++	perm     os.FileMode
+ }
+ 
+ func (w *atomicFileWriter) Write(dt []byte) (int, error) {
+@@ -57,7 +61,7 @@ func (w *atomicFileWriter) Write(dt []byte) (int, error) {
+ 
+ func (w *atomicFileWriter) Close() (retErr error) {
+ 	defer func() {
+-		if retErr != nil {
++		if retErr != nil || w.writeErr != nil {
+ 			os.Remove(w.f.Name())
+ 		}
+ 	}()
+@@ -68,6 +72,9 @@ func (w *atomicFileWriter) Close() (retErr error) {
+ 	if err := w.f.Close(); err != nil {
+ 		return err
+ 	}
++	if err := os.Chmod(w.f.Name(), w.perm); err != nil {
++		return err
++	}
+ 	if w.writeErr == nil {
+ 		return os.Rename(w.f.Name(), w.fn)
+ 	}
+diff --git a/pkg/ioutils/fswriters_test.go b/pkg/ioutils/fswriters_test.go
+index 40717a5..470ca1a 100644
+--- a/pkg/ioutils/fswriters_test.go
++++ b/pkg/ioutils/fswriters_test.go
+@@ -16,7 +16,7 @@ func TestAtomicWriteToFile(t *testing.T) {
+ 	defer os.RemoveAll(tmpDir)
+ 
+ 	expected := []byte("barbaz")
+-	if err := AtomicWriteFile(filepath.Join(tmpDir, "foo"), expected, 0600); err != nil {
++	if err := AtomicWriteFile(filepath.Join(tmpDir, "foo"), expected, 0666); err != nil {
+ 		t.Fatalf("Error writing to file: %v", err)
+ 	}
+ 
+@@ -28,4 +28,12 @@ func TestAtomicWriteToFile(t *testing.T) {
+ 	if bytes.Compare(actual, expected) != 0 {
+ 		t.Fatalf("Data mismatch, expected %q, got %q", expected, actual)
+ 	}
++
++	st, err := os.Stat(filepath.Join(tmpDir, "foo"))
++	if err != nil {
++		t.Fatalf("Error statting file: %v", err)
++	}
++	if expected := os.FileMode(0666); st.Mode() != expected {
++		t.Fatalf("Mode mismatched, expected %o, got %o", expected, st.Mode())
++	}
+ }
+-- 
+2.9.3
+

--- a/meta-resin-common/recipes-containers/docker/docker/0005-Update-layer-store-to-sync-transaction-files-before-.patch
+++ b/meta-resin-common/recipes-containers/docker/docker/0005-Update-layer-store-to-sync-transaction-files-before-.patch
@@ -1,0 +1,320 @@
+From a0855ca751ff9b86f89d58d3ca89ff9a9db1d042 Mon Sep 17 00:00:00 2001
+From: Derek McGowan <derek@mcgstyle.net>
+Date: Tue, 9 Aug 2016 11:55:17 -0700
+Subject: [PATCH 5/5] Update layer store to sync transaction files before
+ committing
+
+Fixes case where shutdown occurs before content is synced to disked
+on layer creation. This case can leave the layer store in an bad
+state and require manual recovery. This change ensures all files
+are synced to disk before a layer is committed. Any shutdown that
+occurs will only cause the layer to not show up but will allow it to
+be repulled or recreated without error.
+
+Added generic io logic to ioutils package to abstract it out of
+the layer store package.
+
+Signed-off-by: Derek McGowan <derek@mcgstyle.net>
+Upstream-Status: Backport
+Signed-off-by: Petros Angelatos <petrosagg@gmail.com>
+---
+ layer/filestore.go            | 26 ++++++------
+ pkg/ioutils/fswriters.go      | 80 +++++++++++++++++++++++++++++++++++
+ pkg/ioutils/fswriters_test.go | 97 ++++++++++++++++++++++++++++++++++++++++++-
+ 3 files changed, 188 insertions(+), 15 deletions(-)
+
+diff --git a/layer/filestore.go b/layer/filestore.go
+index a0044b3..62677d1 100644
+--- a/layer/filestore.go
++++ b/layer/filestore.go
+@@ -32,7 +32,7 @@ type fileMetadataStore struct {
+ 
+ type fileMetadataTransaction struct {
+ 	store *fileMetadataStore
+-	root  string
++	ws    *ioutils.AtomicWriteSet
+ }
+ 
+ // NewFSMetadataStore returns an instance of a metadata store
+@@ -69,37 +69,36 @@ func (fms *fileMetadataStore) StartTransaction() (MetadataTransaction, error) {
+ 	if err := os.MkdirAll(tmpDir, 0755); err != nil {
+ 		return nil, err
+ 	}
+-
+-	td, err := ioutil.TempDir(tmpDir, "layer-")
++	ws, err := ioutils.NewAtomicWriteSet(tmpDir)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+-	// Create a new tempdir
++
+ 	return &fileMetadataTransaction{
+ 		store: fms,
+-		root:  td,
++		ws:    ws,
+ 	}, nil
+ }
+ 
+ func (fm *fileMetadataTransaction) SetSize(size int64) error {
+ 	content := fmt.Sprintf("%d", size)
+-	return ioutil.WriteFile(filepath.Join(fm.root, "size"), []byte(content), 0644)
++	return fm.ws.WriteFile("size", []byte(content), 0644)
+ }
+ 
+ func (fm *fileMetadataTransaction) SetParent(parent ChainID) error {
+-	return ioutil.WriteFile(filepath.Join(fm.root, "parent"), []byte(digest.Digest(parent).String()), 0644)
++	return fm.ws.WriteFile("parent", []byte(digest.Digest(parent).String()), 0644)
+ }
+ 
+ func (fm *fileMetadataTransaction) SetDiffID(diff DiffID) error {
+-	return ioutil.WriteFile(filepath.Join(fm.root, "diff"), []byte(digest.Digest(diff).String()), 0644)
++	return fm.ws.WriteFile("diff", []byte(digest.Digest(diff).String()), 0644)
+ }
+ 
+ func (fm *fileMetadataTransaction) SetCacheID(cacheID string) error {
+-	return ioutil.WriteFile(filepath.Join(fm.root, "cache-id"), []byte(cacheID), 0644)
++	return fm.ws.WriteFile("cache-id", []byte(cacheID), 0644)
+ }
+ 
+ func (fm *fileMetadataTransaction) TarSplitWriter(compressInput bool) (io.WriteCloser, error) {
+-	f, err := os.OpenFile(filepath.Join(fm.root, "tar-split.json.gz"), os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
++	f, err := fm.ws.FileWriter("tar-split.json.gz", os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+@@ -121,15 +120,16 @@ func (fm *fileMetadataTransaction) Commit(layer ChainID) error {
+ 	if err := os.MkdirAll(filepath.Dir(finalDir), 0755); err != nil {
+ 		return err
+ 	}
+-	return os.Rename(fm.root, finalDir)
++
++	return fm.ws.Commit(finalDir)
+ }
+ 
+ func (fm *fileMetadataTransaction) Cancel() error {
+-	return os.RemoveAll(fm.root)
++	return fm.ws.Cancel()
+ }
+ 
+ func (fm *fileMetadataTransaction) String() string {
+-	return fm.root
++	return fm.ws.String()
+ }
+ 
+ func (fms *fileMetadataStore) GetSize(layer ChainID) (int64, error) {
+diff --git a/pkg/ioutils/fswriters.go b/pkg/ioutils/fswriters.go
+index 6dc50a0..a56c462 100644
+--- a/pkg/ioutils/fswriters.go
++++ b/pkg/ioutils/fswriters.go
+@@ -80,3 +80,83 @@ func (w *atomicFileWriter) Close() (retErr error) {
+ 	}
+ 	return nil
+ }
++
++// AtomicWriteSet is used to atomically write a set
++// of files and ensure they are visible at the same time.
++// Must be committed to a new directory.
++type AtomicWriteSet struct {
++	root string
++}
++
++// NewAtomicWriteSet creates a new atomic write set to
++// atomically create a set of files. The given directory
++// is used as the base directory for storing files before
++// commit. If no temporary directory is given the system
++// default is used.
++func NewAtomicWriteSet(tmpDir string) (*AtomicWriteSet, error) {
++	td, err := ioutil.TempDir(tmpDir, "write-set-")
++	if err != nil {
++		return nil, err
++	}
++
++	return &AtomicWriteSet{
++		root: td,
++	}, nil
++}
++
++// WriteFile writes a file to the set, guaranteeing the file
++// has been synced.
++func (ws *AtomicWriteSet) WriteFile(filename string, data []byte, perm os.FileMode) error {
++	f, err := ws.FileWriter(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
++	if err != nil {
++		return err
++	}
++	n, err := f.Write(data)
++	if err == nil && n < len(data) {
++		err = io.ErrShortWrite
++	}
++	if err1 := f.Close(); err == nil {
++		err = err1
++	}
++	return err
++}
++
++type syncFileCloser struct {
++	*os.File
++}
++
++func (w syncFileCloser) Close() error {
++	err := w.File.Sync()
++	if err1 := w.File.Close(); err == nil {
++		err = err1
++	}
++	return err
++}
++
++// FileWriter opens a file writer inside the set. The file
++// should be synced and closed before calling commit.
++func (ws *AtomicWriteSet) FileWriter(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
++	f, err := os.OpenFile(filepath.Join(ws.root, name), flag, perm)
++	if err != nil {
++		return nil, err
++	}
++	return syncFileCloser{f}, nil
++}
++
++// Cancel cancels the set and removes all temporary data
++// created in the set.
++func (ws *AtomicWriteSet) Cancel() error {
++	return os.RemoveAll(ws.root)
++}
++
++// Commit moves all created files to the target directory. The
++// target directory must not exist and the parent of the target
++// directory must exist.
++func (ws *AtomicWriteSet) Commit(target string) error {
++	return os.Rename(ws.root, target)
++}
++
++// String returns the location the set is writing to.
++func (ws *AtomicWriteSet) String() string {
++	return ws.root
++}
+diff --git a/pkg/ioutils/fswriters_test.go b/pkg/ioutils/fswriters_test.go
+index 470ca1a..c4d1419 100644
+--- a/pkg/ioutils/fswriters_test.go
++++ b/pkg/ioutils/fswriters_test.go
+@@ -5,9 +5,21 @@ import (
+ 	"io/ioutil"
+ 	"os"
+ 	"path/filepath"
++	"runtime"
+ 	"testing"
+ )
+ 
++var (
++	testMode os.FileMode = 0640
++)
++
++func init() {
++	// Windows does not support full Linux file mode
++	if runtime.GOOS == "windows" {
++		testMode = 0666
++	}
++}
++
+ func TestAtomicWriteToFile(t *testing.T) {
+ 	tmpDir, err := ioutil.TempDir("", "atomic-writers-test")
+ 	if err != nil {
+@@ -16,7 +28,7 @@ func TestAtomicWriteToFile(t *testing.T) {
+ 	defer os.RemoveAll(tmpDir)
+ 
+ 	expected := []byte("barbaz")
+-	if err := AtomicWriteFile(filepath.Join(tmpDir, "foo"), expected, 0666); err != nil {
++	if err := AtomicWriteFile(filepath.Join(tmpDir, "foo"), expected, testMode); err != nil {
+ 		t.Fatalf("Error writing to file: %v", err)
+ 	}
+ 
+@@ -33,7 +45,88 @@ func TestAtomicWriteToFile(t *testing.T) {
+ 	if err != nil {
+ 		t.Fatalf("Error statting file: %v", err)
+ 	}
+-	if expected := os.FileMode(0666); st.Mode() != expected {
++	if expected := os.FileMode(testMode); st.Mode() != expected {
++		t.Fatalf("Mode mismatched, expected %o, got %o", expected, st.Mode())
++	}
++}
++
++func TestAtomicWriteSetCommit(t *testing.T) {
++	tmpDir, err := ioutil.TempDir("", "atomic-writerset-test")
++	if err != nil {
++		t.Fatalf("Error when creating temporary directory: %s", err)
++	}
++	defer os.RemoveAll(tmpDir)
++
++	if err := os.Mkdir(filepath.Join(tmpDir, "tmp"), 0700); err != nil {
++		t.Fatalf("Error creating tmp directory: %s", err)
++	}
++
++	targetDir := filepath.Join(tmpDir, "target")
++	ws, err := NewAtomicWriteSet(filepath.Join(tmpDir, "tmp"))
++	if err != nil {
++		t.Fatalf("Error creating atomic write set: %s", err)
++	}
++
++	expected := []byte("barbaz")
++	if err := ws.WriteFile("foo", expected, testMode); err != nil {
++		t.Fatalf("Error writing to file: %v", err)
++	}
++
++	if _, err := ioutil.ReadFile(filepath.Join(targetDir, "foo")); err == nil {
++		t.Fatalf("Expected error reading file where should not exist")
++	}
++
++	if err := ws.Commit(targetDir); err != nil {
++		t.Fatalf("Error committing file: %s", err)
++	}
++
++	actual, err := ioutil.ReadFile(filepath.Join(targetDir, "foo"))
++	if err != nil {
++		t.Fatalf("Error reading from file: %v", err)
++	}
++
++	if bytes.Compare(actual, expected) != 0 {
++		t.Fatalf("Data mismatch, expected %q, got %q", expected, actual)
++	}
++
++	st, err := os.Stat(filepath.Join(targetDir, "foo"))
++	if err != nil {
++		t.Fatalf("Error statting file: %v", err)
++	}
++	if expected := os.FileMode(testMode); st.Mode() != expected {
+ 		t.Fatalf("Mode mismatched, expected %o, got %o", expected, st.Mode())
+ 	}
++
++}
++
++func TestAtomicWriteSetCancel(t *testing.T) {
++	tmpDir, err := ioutil.TempDir("", "atomic-writerset-test")
++	if err != nil {
++		t.Fatalf("Error when creating temporary directory: %s", err)
++	}
++	defer os.RemoveAll(tmpDir)
++
++	if err := os.Mkdir(filepath.Join(tmpDir, "tmp"), 0700); err != nil {
++		t.Fatalf("Error creating tmp directory: %s", err)
++	}
++
++	ws, err := NewAtomicWriteSet(filepath.Join(tmpDir, "tmp"))
++	if err != nil {
++		t.Fatalf("Error creating atomic write set: %s", err)
++	}
++
++	expected := []byte("barbaz")
++	if err := ws.WriteFile("foo", expected, testMode); err != nil {
++		t.Fatalf("Error writing to file: %v", err)
++	}
++
++	if err := ws.Cancel(); err != nil {
++		t.Fatalf("Error committing file: %s", err)
++	}
++
++	if _, err := ioutil.ReadFile(filepath.Join(tmpDir, "target", "foo")); err == nil {
++		t.Fatalf("Expected error reading file where should not exist")
++	} else if !os.IsNotExist(err) {
++		t.Fatalf("Unexpected error reading file: %s", err)
++	}
+ }
+-- 
+2.9.3
+

--- a/meta-resin-common/recipes-containers/docker/docker_git.bb
+++ b/meta-resin-common/recipes-containers/docker/docker_git.bb
@@ -27,6 +27,9 @@ SRC_URI = "\
   file://0001-bucket-correct-broken-unaligned-load-store-in-armv5.patch \
   file://journal.patch \
   file://0002-Inherit-StopSignal-from-Dockerfile.patch \
+  file://0003-Safer-file-io-for-configuration-files.patch \
+  file://0004-Set-permission-on-atomic-file-write.patch \
+  file://0005-Update-layer-store-to-sync-transaction-files-before-.patch \
 	"
 
 # Apache-2.0 for docker


### PR DESCRIPTION
This set of patches make sure that changes in the layer store are synced
to disk before updating the metadata of docker.

connects to docker/docker#25523
fixes resin-io/hq#274

Signed-off-by: Petros Angelatos <petrosagg@gmail.com>