### PR TITLE
Update supervisor to v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Update supervisor to v2.1.0 [Pablo]
 * Use FHS structure in the root of resinhup packages [Andrei]
 
 # v1.11 - 2016-08-31

--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
@@ -1,7 +1,7 @@
 require docker-disk.inc
 
 TARGET_REPOSITORY ?= "${SUPERVISOR_REPOSITORY}"
-TARGET_TAG ?= "v1.14.0"
+TARGET_TAG ?= "v2.1.0"
 LED_FILE ?= "/dev/null"
 
 inherit systemd


### PR DESCRIPTION
connects to #278 
Depends on resin-io/resin-ui#23 (which has yet to be deployed to production)