### PR TITLE
resin-supervisor.service: Move the docker container removal in ExecSt…

### DIFF
--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/resin-supervisor.service
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/resin-supervisor.service
@@ -15,8 +15,6 @@ Restart=always
 RestartSec=10s
 EnvironmentFile=/etc/supervisor.conf
 EnvironmentFile=-/tmp/update-supervisor.conf
-ExecStartPre=-@BINDIR@/docker stop resin_supervisor
-ExecStartPre=-@BINDIR@/docker rm --force resin_supervisor
 ExecStart=@BASE_BINDIR@/bash -c 'source @SBINDIR@/resin-vars && \
     @BINDIR@/docker run --privileged --name resin_supervisor \
     --net=host \
@@ -38,8 +36,8 @@ ExecStart=@BASE_BINDIR@/bash -c 'source @SBINDIR@/resin-vars && \
     -e LISTEN_PORT=$LISTEN_PORT \
     -e SUPERVISOR_IMAGE=${SUPERVISOR_IMAGE} \
     ${SUPERVISOR_IMAGE}'
-ExecStop=-@BINDIR@/docker stop resin_supervisor
-ExecStop=-@BINDIR@/docker rm --force resin_supervisor
+ExecStop=@BINDIR@/docker stop -t 2 resin_supervisor
+ExecStopPost=@BINDIR@/docker rm --force resin_supervisor
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
…opPost

ExecStopPost commands will be called after the service is stopped. This includes cases when
the commands configured in ExecStop= were used, where the service does not have any ExecStop= defined,
or where the service exited unexpectedly. This is the place to have the container removal instead of in
ExecStop because the commands specified in ExecStop= are only executed when the service started successfully
first.

We also tweak the ExecStop command in the sense of adding a 2 seconds timeout after which docker will send
the SIGKILL signal.

Signed-off-by: Florin Sarbu <florin@resin.io>