### PR TITLE
resin.conf: Change the TUN device used by OpenVPN to resin-vpn 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Change the TUN device used by OpenVPN to resin-vpn to minimize conflict with user applications using tun0 [Praneeth]
 * Update supervisor to v2.1.0 [Pablo]
 * Use FHS structure in the root of resinhup packages [Andrei]
 

--- a/meta-resin-common/recipes-connectivity/openvpn/openvpn/resin.conf
+++ b/meta-resin-common/recipes-connectivity/openvpn/openvpn/resin.conf
@@ -12,7 +12,8 @@ up-restart
 down /etc/openvpn/downscript.sh
 
 comp-lzo
-dev tun
+dev resin-vpn
+dev-type tun
 proto tcp
 nobind
 


### PR DESCRIPTION
This prevents conflict with user applications using tun0

Connects to #282 

This requires https://github.com/resin-io/resin-supervisor/issues/247 to be deployed before being deployed to HOSTOS