### PR TITLE
docker-resin-supervisor-disk: Update supervisor to v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Update supervisor to v2.2.0 [Kostas]
+
 # v1.13 - 2016-09-23
 
 # v1.12 - 2016-09-21

--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
@@ -1,7 +1,7 @@
 require docker-disk.inc
 
 TARGET_REPOSITORY ?= "${SUPERVISOR_REPOSITORY}"
-TARGET_TAG ?= "v2.1.1"
+TARGET_TAG ?= "v2.2.0"
 LED_FILE ?= "/dev/null"
 
 inherit systemd


### PR DESCRIPTION
Connects to #325