### PR TITLE
Install and configure avahi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Integrate and configure avahi [Andrei]
 * Start using gzip archives for kernel module headers [Andrei]
 * Replace DEBUG_IMAGE with DEVELOPMENT_IMAGE [Theodor]
 * Update supervisor to v2.5.0 [Pablo]

--- a/meta-resin-common/recipes-connectivity/avahi/avahi_%.bbappend
+++ b/meta-resin-common/recipes-connectivity/avahi/avahi_%.bbappend
@@ -1,0 +1,6 @@
+do_install_append() {
+    # Move example services as we don't want to advertise example services
+    install -d ${D}/usr/share/doc/${PN}
+    mv ${D}/etc/avahi/services/ssh.service ${D}/usr/share/doc/${PN}/
+    mv ${D}/etc/avahi/services/sftp-ssh.service ${D}/usr/share/doc/${PN}/
+}

--- a/meta-resin-common/recipes-core/dropbear/dropbear_%.bbappend
+++ b/meta-resin-common/recipes-core/dropbear/dropbear_%.bbappend
@@ -3,6 +3,7 @@ SRC_URI += " \
     file://atomic-hostkey.patch \
     file://dropbear.socket \
     file://failsafe-sshkey.pub \
+    file://ssh.service \
     "
 
 FILES_${PN} += "/home"
@@ -24,5 +25,9 @@ do_install_append() {
 
     install -d ${D}${sysconfdir}/default
     echo 'DROPBEAR_PORT="22222"' >> ${D}/etc/default/dropbear # Change default dropbear port to 22222
+
+    # Advertise SSH service using an avahi service file
+    mkdir -p ${D}/etc/avahi/services
+    install -m 0644 ${WORKDIR}/ssh.service ${D}/etc/avahi/services
 }
 do_install[vardeps] += "DISTRO_FEATURES"

--- a/meta-resin-common/recipes-core/dropbear/files/ssh.service
+++ b/meta-resin-common/recipes-core/dropbear/files/ssh.service
@@ -1,0 +1,34 @@
+<?xml version="1.0" standalone='no'?><!--*-nxml-*-->
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+
+<!--
+  This file is part of avahi.
+ 
+  avahi is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation; either version 2 of the
+  License, or (at your option) any later version.
+
+  avahi is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with avahi; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+  02111-1307 USA.
+-->
+
+<!-- See avahi.service(5) for more information about this configuration file -->
+
+<service-group>
+
+  <name replace-wildcards="yes">%h</name>
+
+  <service>
+    <type>_ssh._tcp</type>
+    <port>22222</port>
+  </service>
+
+</service-group>

--- a/meta-resin-common/recipes-core/packagegroups/packagegroup-resin-connectivity.bb
+++ b/meta-resin-common/recipes-core/packagegroups/packagegroup-resin-connectivity.bb
@@ -22,6 +22,7 @@ CONNECTIVITY_PACKAGES = " \
     wireless-tools \
     openvpn \
     crda \
+    avahi-daemon \
     "
 
 RDEPENDS_${PN} = " \


### PR DESCRIPTION
Connects to #317 

Avahi daemon on the device advertise the following services:
```
+ wlp4s0 IPv4 raspberrypi3 [b8:27:eb:a5:7d:b0]              Workstation          local
+ wlp4s0 IPv4 raspberrypi3                                  SSH Remote Terminal  local
= wlp4s0 IPv4 raspberrypi3 [b8:27:eb:a5:7d:b0]              Workstation          local
   hostname = [raspberrypi3.local]
   address = [192.168.1.167]
   port = [9]
   txt = []
= wlp4s0 IPv4 raspberrypi3                                  SSH Remote Terminal  local
   hostname = [raspberrypi3.local]
   address = [192.168.1.167]
   port = [22222]
   txt = []
```

Example of ssh-ing on a device:
```
andrei@resin ~ $ ssh -p 22222 root@raspberrypi3.local
The authenticity of host '[raspberrypi3.local]:22222 ([192.168.1.167]:22222)' can't be established.
RSA key fingerprint is SHA256:cSP2z7aCpR1XHNgKqgHTG71cOX9hj4rPZKfIn1jCupg.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added '[raspberrypi3.local]:22222,[192.168.1.167]:22222' (RSA) to the list of known hosts.
root@raspberrypi3:~#
```