### PR TITLE
docker-resin-supervisor-disk: Update supervisor to v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Update supervisor to v2.5.0 [Pablo]
+
 # v1.16 - 2016-09-27
 
 * Update supervisor to v2.3.0 [Pablo]

--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
@@ -1,7 +1,7 @@
 require docker-disk.inc
 
 TARGET_REPOSITORY ?= "${SUPERVISOR_REPOSITORY}"
-TARGET_TAG ?= "v2.3.0"
+TARGET_TAG ?= "v2.5.0"
 LED_FILE ?= "/dev/null"
 
 inherit systemd


### PR DESCRIPTION
connects to #344 
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>
Depends on resin-io/resin-api#50