### PR TITLE
Update module headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Update kernel-module-headers to v0.0.7 [Lorenzo]
 * Implement persistent logging functionality [Andrei]
 * Increase the root filesystem size to 300M [Andrei]
 * Bump supervisor to 2.5.2 [Andrei]

--- a/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
+++ b/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
@@ -29,7 +29,7 @@ do_compile() {
     else
         TGT_ARCH=${TRANSLATED_TARGET_ARCH}
     fi
-    ${S}/gen_mod_headers ./kernel_modules_headers ${STAGING_KERNEL_DIR} ${DEPLOY_DIR_IMAGE} ${TGT_ARCH} ${TARGET_PREFIX}
+    ${S}/gen_mod_headers ./kernel_modules_headers ${STAGING_KERNEL_DIR} ${DEPLOY_DIR_IMAGE} ${TGT_ARCH} ${TARGET_PREFIX} "${CC}"
     tar -czf kernel_modules_headers.tar.gz kernel_modules_headers
     rm -rf kernel_modules_headers
 }

--- a/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
+++ b/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
@@ -11,7 +11,7 @@ DEPENDS = "virtual/kernel"
 
 SRC_URI = "git://github.com/resin-os/module-headers.git;protocol=https"
 
-SRCREV = "7787ed1393f8a45334f0342e29bdc3a4a2ddcf93"
+SRCREV = "v0.0.7"
 
 S = "${WORKDIR}/git"
 B = "${WORKDIR}"


### PR DESCRIPTION
The latest update of the script fixes the isue with binaries in `scripts/` being built for the host arch rather than the target arch which makes the headers useless for building on target arch or emulated target arch.