### PR TITLE
networkmanager_%.bbappend: Fix appending to PACKAGECONFIG

### DIFF
--- a/meta-resin-common/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/meta-resin-common/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -10,7 +10,7 @@ SRC_URI_append = " \
 RDEPENDS_${PN}_append = " resin-net-config resolvconf"
 FILES_${PN}_append = "${sysconfdir}/*"
 EXTRA_OECONF += "--with-resolvconf=/sbin/resolvconf"
-PACKAGECONFIG += "systemd modemmanager ppp"
+PACKAGECONFIG_append = " systemd modemmanager ppp"
 PACKAGES += "${PN}-bash-completion"
 
 FILES_${PN}-bash-completion = "${datadir}/bash-completion"


### PR DESCRIPTION
It looks like "PACKAGECONFIG +=" does not actually append but rather just
sets the PACKAGECONFIG variable to these values.

Signed-off-by: Florin Sarbu <florin@resin.io>