### PR TITLE
multi-user.conf: Also require resin-bind.target

### DIFF
--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/multi-user.conf
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/multi-user.conf
@@ -1,2 +1,2 @@
 [Unit]
-Requires=resin.target
+Requires=resin.target resin-bind.target


### PR DESCRIPTION
This will allow resin-bind.target to start, othwerwise it does not get started

Signed-off-by: Florin Sarbu <florin@resin.io>

Fixes #387 