### PR TITLE
avahi_%.bbappend: Add dependency on resin-hostname.service

### DIFF
--- a/meta-resin-common/recipes-connectivity/avahi/avahi_%.bbappend
+++ b/meta-resin-common/recipes-connectivity/avahi/avahi_%.bbappend
@@ -1,6 +1,13 @@
+SRC_URI_append = " file://avahi-daemon.conf"
+
 do_install_append() {
     # Move example services as we don't want to advertise example services
     install -d ${D}/usr/share/doc/${PN}
     mv ${D}/etc/avahi/services/ssh.service ${D}/usr/share/doc/${PN}/
     mv ${D}/etc/avahi/services/sftp-ssh.service ${D}/usr/share/doc/${PN}/
+
+    if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+        install -d ${D}${sysconfdir}/systemd/system/avahi-daemon.service.d
+        install -c -m 0644 ${WORKDIR}/avahi-daemon.conf ${D}${sysconfdir}/systemd/system/avahi-daemon.service.d
+    fi
 }

--- a/meta-resin-common/recipes-connectivity/avahi/files/avahi-daemon.conf
+++ b/meta-resin-common/recipes-connectivity/avahi/files/avahi-daemon.conf
@@ -1,0 +1,2 @@
+Requires=resin-hostname.service
+After=resin-hostname.service


### PR DESCRIPTION
We need to make sure the hostname is set before having avahi
start advertising.

Signed-off-by: Florin Sarbu <florin@resin.io>