### PR TITLE
dropbear_%.bbappend: Add Require and After on etc-dropbear.mount

### DIFF
--- a/meta-resin-common/recipes-core/dropbear/dropbear_%.bbappend
+++ b/meta-resin-common/recipes-core/dropbear/dropbear_%.bbappend
@@ -4,6 +4,7 @@ SRC_URI += " \
     file://dropbear.socket \
     file://failsafe-sshkey.pub \
     file://ssh.service \
+    file://dropbearkey.conf \
     "
 
 FILES_${PN} += "/home"
@@ -29,5 +30,11 @@ do_install_append() {
     # Advertise SSH service using an avahi service file
     mkdir -p ${D}/etc/avahi/services
     install -m 0644 ${WORKDIR}/ssh.service ${D}/etc/avahi/services
+
+    if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+        install -d ${D}${sysconfdir}/systemd/system/dropbearkey.service.d
+        install -c -m 0644 ${WORKDIR}/dropbearkey.conf ${D}${sysconfdir}/systemd/system/dropbearkey.service.d
+    fi
+
 }
 do_install[vardeps] += "DISTRO_FEATURES"

--- a/meta-resin-common/recipes-core/dropbear/files/dropbearkey.conf
+++ b/meta-resin-common/recipes-core/dropbear/files/dropbearkey.conf
@@ -1,0 +1,3 @@
+[Unit]
+Requires=etc-dropbear.mount
+After=etc-dropbear.mount


### PR DESCRIPTION
We need /etc/dropbear/ bind mounted to our read-write location when
dropbear will attempt to write the host key there.

Signed-off-by: Florin Sarbu <florin@resin.io>

Fixes #387 