### PR TITLE
networkmanager: Add hidden setting to sample config file

### DIFF
--- a/meta-resin-common/recipes-connectivity/networkmanager/files/resin-sample
+++ b/meta-resin-common/recipes-connectivity/networkmanager/files/resin-sample
@@ -3,6 +3,7 @@ id=resin-sample
 type=wifi
 
 [wifi]
+hidden=true
 mode=infrastructure
 ssid=My_Wifi_Ssid
 


### PR DESCRIPTION
Adding "hidden=true" for being able to connect to hidden SSIDs too.

Signed-off-by: Florin Sarbu <florin@resin.io>