### PR TITLE
nm: ignore bridge, tun, and veth type devices

### DIFF
--- a/meta-resin-common/recipes-connectivity/networkmanager/files/NetworkManager.conf
+++ b/meta-resin-common/recipes-connectivity/networkmanager/files/NetworkManager.conf
@@ -3,4 +3,4 @@ dns=default
 plugins=keyfile
 
 [keyfile]
-unmanaged-devices=interface-name:docker*;tun*
+unmanaged-devices=type:bridge;type:tun;type:veth


### PR DESCRIPTION
NetworkManager tries to configure the virtual ethernet devices created
by docker otherwise.

Signed-off-by: Petros Angelatos <petrosagg@gmail.com>