### PR TITLE
resin-mounts-flasher.bb: Add mount unit for bind mounting system-conn…

### DIFF
--- a/meta-resin-common/recipes-support/resin-mounts/resin-mounts-flasher.bb
+++ b/meta-resin-common/recipes-support/resin-mounts/resin-mounts-flasher.bb
@@ -7,6 +7,7 @@ SRC_URI = " \
     file://mnt-bootorig-config.json.mount \
     file://temp-conf.service \
     file://mnt-bootorig.mount \
+    file://etc-NetworkManager-systemx2dconnections.mount \
     "
 
 S = "${WORKDIR}"
@@ -45,5 +46,9 @@ do_install () {
             -e 's,@SBINDIR@,${sbindir},g' \
             -e 's,@BINDIR@,${bindir},g' \
             ${D}${sysconfdir}/systemd/system/*
+
+        # Yocto gets confused if we use strange file names - so we rename it here
+        # https://bugzilla.yoctoproject.org/show_bug.cgi?id=8161
+        install -c -m 0644 ${WORKDIR}/etc-NetworkManager-systemx2dconnections.mount ${D}${sysconfdir}/systemd/system/etc-NetworkManager-system\\x2dconnections.mount
     fi
 }

--- a/meta-resin-common/recipes-support/resin-mounts/resin-mounts-flasher/etc-NetworkManager-systemx2dconnections.mount
+++ b/meta-resin-common/recipes-support/resin-mounts/resin-mounts-flasher/etc-NetworkManager-systemx2dconnections.mount
@@ -1,0 +1,13 @@
+[Unit]
+Description=NetworkManager system connections bind mount
+Requires=mnt-conf.mount resin-conf-reset.service
+After=mnt-conf.mount resin-conf-reset.service
+
+[Mount]
+What=/mnt/conf/root-overlay/etc/NetworkManager/system-connections
+Where=/etc/NetworkManager/system-connections
+Type=None
+Options=bind
+
+[Install]
+WantedBy=resin-bind.target


### PR DESCRIPTION
…ections

We need /etc/NetworkManager/system-connections bind mounted to a read-write location
also for when using the flasher

Signed-off-by: Florin Sarbu <florin@resin.io>