### PR TITLE
docker-resin-supervisor-disk: Update supervisor to 2.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Update supervisor to v2.6.3 [Pablo]
 * Update supervisor to v2.6.2 [Pablo]
 * Configure kernel with CONFIG_SECCOMP [Andrei]
 * Update kernel-module-headers to v0.0.7 [Lorenzo]

--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
@@ -1,7 +1,7 @@
 require docker-disk.inc
 
 TARGET_REPOSITORY ?= "${SUPERVISOR_REPOSITORY}"
-TARGET_TAG ?= "v2.6.2"
+TARGET_TAG ?= "v2.6.3"
 LED_FILE ?= "/dev/null"
 
 inherit systemd


### PR DESCRIPTION
connects to #425 
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>