### PR TITLE
ucl_1.03.bb: Fix ACC conformance test

### DIFF
--- a/meta-resin-common/recipes-core/ucl/ucl_1.03.bb
+++ b/meta-resin-common/recipes-core/ucl/ucl_1.03.bb
@@ -7,7 +7,10 @@ SRC_URI = " \
     http://www.oberhumer.com/opensource/ucl/download/ucl-1.03.tar.gz \
     file://0001-configure.ac-Fix-with-current-autoconf.patch \
     file://0002-acinclude.m4-Provide-missing-macros.patch"
+
 SRC_URI[md5sum] = "852bd691d8abc75b52053465846fba34"
 SRC_URI[sha256sum] = "b865299ffd45d73412293369c9754b07637680e5c826915f097577cd27350348"
 
 inherit autotools native
+
+CFLAGS += "-std=c90"


### PR DESCRIPTION
configure error on gcc6

This commit fixes(by using the ISO C90 standard) the following ucl configure error on gcc6:

| checking for vsnprintf... yes
| checking whether your compiler passes the ACC conformance test... FAILED
| configure:
| configure: Your compiler failed the ACC conformance test - for details see
| configure: `config.log'. Please check that log file and consider sending
| configure: a patch or bug-report to <markus@oberhumer.com>.
| configure: Thanks for your support.
| configure:
| configure: error: ACC conformance test failed. Stop.
| NOTE: The following config.log files may provide further information.

Signed-off-by: Florin Sarbu <florin@resin.io>