### PR TITLE
docker-resin-supervisor-disk: Update supervisor to 2.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Update supervisor to v2.6.3 [Pablo]
+
 # v1.6 - 2016-07-06
 
 # v1.5 - 2016-07-04

--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
@@ -1,7 +1,7 @@
 require docker-disk.inc
 
 TARGET_REPOSITORY ?= "${SUPERVISOR_REPOSITORY}"
-TARGET_TAG ?= "v1.11.6"
+TARGET_TAG ?= "v2.6.3"
 LED_FILE ?= "/dev/null"
 
 inherit systemd


### PR DESCRIPTION
connect https://github.com/resin-os/meta-resin/pull/426