### PR TITLE
upx_3.91.bb: Fix indentation error on gcc6

### DIFF
--- a/meta-resin-common/recipes-core/upx/files/fix_indentation_for_gcc6.patch
+++ b/meta-resin-common/recipes-core/upx/files/fix_indentation_for_gcc6.patch
@@ -1,0 +1,29 @@
+Upstream-Status: Pending
+
+Signed-off-by: Florin Sarbu <florin@resin.io>
+
+Index: upx-3.91-src/src/p_vmlinx.cpp
+===================================================================
+--- upx-3.91-src.orig/src/p_vmlinx.cpp
++++ upx-3.91-src/src/p_vmlinx.cpp
+@@ -94,11 +94,15 @@ PackVmlinuxBase<T>::compare_Phdr(void co
+     Phdr const *const b = (Phdr const *)bb;
+     unsigned const xa = a->p_type - Phdr::PT_LOAD;
+     unsigned const xb = b->p_type - Phdr::PT_LOAD;
+-            if (xa < xb)         return -1;  // PT_LOAD first
+-            if (xa > xb)         return  1;
+-    if (a->p_paddr < b->p_paddr) return -1;  // ascending by .p_paddr
+-    if (a->p_paddr > b->p_paddr) return  1;
+-                                 return  0;
++    if (xa < xb)
++         return -1;  // PT_LOAD first
++    if (xa > xb)
++         return  1;
++    if (a->p_paddr < b->p_paddr)
++        return -1;  // ascending by .p_paddr
++    if (a->p_paddr > b->p_paddr)
++        return  1;
++    return  0;
+ }
+ 
+ template <class T>

--- a/meta-resin-common/recipes-core/upx/upx_3.91.bb
+++ b/meta-resin-common/recipes-core/upx/upx_3.91.bb
@@ -4,6 +4,7 @@ SUMMARY = "Ultimate executable compressor."
 SRC_URI = " \
     http://upx.sourceforge.net/download/${PN}-${PV}-src.tar.bz2 \
     http://downloads.sourceforge.net/sevenzip/lzma465.tar.bz2;name=lzma;subdir=lzma-465 \
+    file://fix_indentation_for_gcc6.patch \
     "
 
 SRC_URI[md5sum] = "c6d0b3ea2ecb28cb8031d59a4b087a43"


### PR DESCRIPTION
This fixes the following compile crash on gcc6:

| p_vmlinx.cpp: In static member function 'static int PackVmlinuxBase<TElfClass>::compare_Phdr(const void*, const void*)':
| p_vmlinx.cpp:100:5: error: this 'if' clause does not guard... [-Werror=misleading-indentation]
|      if (a->p_paddr > b->p_paddr) return  1;
|      ^~
| p_vmlinx.cpp:101:34: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
|                                   return  0;
|                                   ^~~~~~

Signed-off-by: Florin Sarbu <florin@resin.io>