### PR TITLE
networkmanager_1.4.2.bb: Enable gobject-introspection

### DIFF
--- a/meta-resin-common/recipes-connectivity/networkmanager/networkmanager_1.4.2.bb
+++ b/meta-resin-common/recipes-connectivity/networkmanager/networkmanager_1.4.2.bb
@@ -13,7 +13,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=cbbffd568227ada506640fe950a4823b \
 
 DEPENDS = "intltool-native libnl dbus dbus-glib dbus-glib-native libgudev util-linux libndp libnewt polkit"
 
-inherit gnomebase gettext systemd bluetooth vala
+inherit gobject-introspection gnomebase gettext systemd bluetooth vala
 
 SRC_URI = " \
     ${GNOME_MIRROR}/NetworkManager/${@gnome_verdir("${PV}")}/NetworkManager-${PV}.tar.xz \
@@ -69,7 +69,12 @@ PACKAGES =+ "libnmutil libnmglib libnmglib-vpn ${PN}-tests \
 "
 
 FILES_libnmutil += "${libdir}/libnm-util.so.*"
-FILES_libnmglib += "${libdir}/libnm-glib.so.*"
+
+FILES_libnmglib += " \
+    ${libdir}/libnm-glib.so.* \
+    ${libdir}/girepository-*/*.typelib \ 
+    "
+
 FILES_libnmglib-vpn += "${libdir}/libnm-glib-vpn.so.*"
 
 FILES_${PN}-adsl = "${libdir}/NetworkManager/libnm-device-plugin-adsl.so"


### PR DESCRIPTION
THIS PULL REQUEST IS SUPPOSED TO BE MERGED WHEN ALL BOARDS MIGRATE TO KROGOTH!

Poky krogoth adds support for GObject introspection data.
Without enabling introspection in NetworkManager, the build will fail with the error:

| make[4]: **\* No rule to make target 'NM-1.0.typelib', needed by 'all-am'.  Stop.

This commit enables gobject-introspection inheritance to get rid of the build error and
as we do not use GObject introspection, we do not add the introspection data to the main
package, but rather add it to the libnmglib package.

Signed-off-by: Florin Sarbu florin@resin.io
