### PR TITLE
docker-resin-supervisor-disk: Update supervisor to v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Update supervisor to v2.7.0 [Pablo]
 * Add guide for new board adoption [Florin]
 * Update supervisor to v2.6.2 [Pablo]
 * Configure kernel with CONFIG_SECCOMP [Andrei]

--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
@@ -1,7 +1,7 @@
 require docker-disk.inc
 
 TARGET_REPOSITORY ?= "${SUPERVISOR_REPOSITORY}"
-TARGET_TAG ?= "v2.6.2"
+TARGET_TAG ?= "v2.7.0"
 LED_FILE ?= "/dev/null"
 
 inherit systemd


### PR DESCRIPTION
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>

Connects to #440 