### PR TITLE
docker-resin-supervisor-disk: Update supervisor to v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Update supervisor to v2.7.0 [Pablo]
+
 # v1.17 - 2016-10-21
 
 * Update supervisor to v2.6.3 [Pablo]

--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
@@ -1,7 +1,7 @@
 require docker-disk.inc
 
 TARGET_REPOSITORY ?= "${SUPERVISOR_REPOSITORY}"
-TARGET_TAG ?= "v2.6.3"
+TARGET_TAG ?= "v2.7.0"
 LED_FILE ?= "/dev/null"
 
 inherit systemd


### PR DESCRIPTION
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>

Also PRd to master, but this version also has fixes that are relevant to 1.X.