### PR TITLE
resin-hostname: use just the first 7 characters of the uuid for the hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Truncate hostname to 7 characters [Michal]
 * Fix aufs patching on non git kernel sources [Andrei]
 * Update supervisor to v2.8.1 [Pablo]
 

--- a/meta-resin-common/recipes-support/resin-hostname/resin-hostname/resin-hostname
+++ b/meta-resin-common/recipes-support/resin-hostname/resin-hostname/resin-hostname
@@ -5,7 +5,8 @@ set -e
 . /usr/sbin/resin-vars
 
 if [ -z "$CONFIG_HOSTNAME" ]; then
-    CONFIG_HOSTNAME=$(jq -r '.uuid //empty' $CONFIG_PATH)
+    # take just the first 7 characters
+    CONFIG_HOSTNAME=$(jq -r '.uuid //empty' $CONFIG_PATH | sed -e 's/\(.......\).*/\1/')
 fi
 
 if [ -z "$CONFIG_HOSTNAME" ]; then


### PR DESCRIPTION
If the string is shorter than 7 characters, use what's provided.

connect https://github.com/resin-os/resinos/issues/101
