### PR TITLE
resin-image-flasher.bb: Make the sdcard image creation

### DIFF
--- a/meta-resin-common/recipes-core/images/resin-image-flasher.bb
+++ b/meta-resin-common/recipes-core/images/resin-image-flasher.bb
@@ -6,8 +6,8 @@ inherit image-resin
 # Each machine should append this with their specific configuration
 IMAGE_FSTYPES = ""
 
-# Make sure you have the resin image ready
-IMAGE_DEPENDS_resin-sdcard_append = " resin-image:do_rootfs"
+# Make sure you have the sdcard resin image ready
+IMAGE_DEPENDS_resin-sdcard_append = " resin-image:do_image_resin_sdcard"
 
 IMAGE_FEATURES_append = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'development-image', 'debug-tweaks', '', d)} \


### PR DESCRIPTION
WARNING: This PR is applicable to newer poky version ( >= krogoth )

depend on resin-image:do_image_resin_sdcard rather than
just need resin-image:do_rootfs

The task add_resin_image_to_flasher_rootfs expects the sdcard image
to be created, not just the rootfs to exist at the time it is called.

Signed-off-by: Florin Sarbu <florin@resin.io>