### PR TITLE
host-update-resin.bbclass: Explicitly reference rootfs tar archive

### DIFF
--- a/meta-resin-common/classes/host-update-resin.bbclass
+++ b/meta-resin-common/classes/host-update-resin.bbclass
@@ -23,7 +23,7 @@ IMAGE_CMD_resinhup-tar () {
 
     # Populate
     mcopy -i ${WORKDIR}/boot.img -sv ::/ ${RESIN_HUP_TEMP_DIR_BOOT}
-    tar -xf ${IMAGE_NAME}.rootfs.tar -C ${RESIN_HUP_TEMP_DIR}
+    tar -xf ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.tar -C ${RESIN_HUP_TEMP_DIR}
 
     # Quirks
     # We need to save some files that docker shadows with bind mounts


### PR DESCRIPTION
Point to deploy directory when referring to the rootfs tar archive. Newer poky
versions (>= krogoth) error out complaining the archive is not found. Specifying
here the full path fixes this problem.

Signed-off-by: Florin Sarbu <florin@resin.io>