### PR TITLE
docker: fix durable writing of image layers to disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Fix /var/lib/docker corruption after power cut [petrosagg]
 * Truncate hostname to 7 characters [Michal]
 * Fix aufs patching on non git kernel sources [Andrei]
 * Update supervisor to v2.8.1 [Pablo]

--- a/meta-resin-common/recipes-containers/docker/docker/0009-graph-aufs-durably-write-layer-on-disk-before-return.patch
+++ b/meta-resin-common/recipes-containers/docker/docker/0009-graph-aufs-durably-write-layer-on-disk-before-return.patch
@@ -1,0 +1,33 @@
+From bfc1c2ba635c786dda8aae0809fd2f3cac96a560 Mon Sep 17 00:00:00 2001
+From: Petros Angelatos <petrosagg@gmail.com>
+Date: Thu, 3 Nov 2016 00:38:14 +0000
+Subject: [PATCH] graph: aufs: durably write layer on disk before returning
+
+This patch makes sure the layer contents are synced to disk before
+reporting the ApplyDiff operation as successful. This prevents
+/var/lib/docker corruption but the method used here is not the most
+efficient since it will sync all the currently mounted filesystems.
+
+Signed-off-by: Petros Angelatos <petrosagg@gmail.com>
+---
+ daemon/graphdriver/aufs/aufs.go | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/daemon/graphdriver/aufs/aufs.go b/daemon/graphdriver/aufs/aufs.go
+index 51054fa..797f1ad 100644
+--- a/daemon/graphdriver/aufs/aufs.go
++++ b/daemon/graphdriver/aufs/aufs.go
+@@ -397,6 +397,10 @@ func (a *Driver) ApplyDiff(id, parent string, diff archive.Reader) (size int64,
+ 		return
+ 	}
+ 
++	// FIXME: Instead of syncing all the filesystems we should be fsyncing each
++	// file as the tar archive gets unpacked
++	syscall.Sync()
++
+ 	return a.DiffSize(id, parent)
+ }
+ 
+-- 
+2.10.2
+

--- a/meta-resin-common/recipes-containers/docker/docker/0010-pkg-ioutils-sync-parent-directory-too.patch
+++ b/meta-resin-common/recipes-containers/docker/docker/0010-pkg-ioutils-sync-parent-directory-too.patch
@@ -1,0 +1,65 @@
+From b92d1dc29d8e6b542a1bcb1fa1d33dfb25045a16 Mon Sep 17 00:00:00 2001
+From: Petros Angelatos <petrosagg@gmail.com>
+Date: Thu, 3 Nov 2016 17:25:12 +0000
+Subject: [PATCH] pkg/ioutils: sync parent directory too
+
+After renaming the file to the target path the parent directory needs to
+be synced to make sure the rename hits the disk.
+
+Signed-off-by: Petros Angelatos <petrosagg@gmail.com>
+---
+ pkg/ioutils/fswriters.go | 23 +++++++++++++++++++----
+ 1 file changed, 19 insertions(+), 4 deletions(-)
+
+diff --git a/pkg/ioutils/fswriters.go b/pkg/ioutils/fswriters.go
+index a56c462..7018476 100644
+--- a/pkg/ioutils/fswriters.go
++++ b/pkg/ioutils/fswriters.go
+@@ -5,6 +5,7 @@ import (
+ 	"io/ioutil"
+ 	"os"
+ 	"path/filepath"
++	"syscall"
+ )
+ 
+ // NewAtomicFileWriter returns WriteCloser so that writing to it writes to a
+@@ -65,6 +66,9 @@ func (w *atomicFileWriter) Close() (retErr error) {
+ 			os.Remove(w.f.Name())
+ 		}
+ 	}()
++	if err := w.f.Chmod(w.perm); err != nil {
++		return err
++	}
+ 	if err := w.f.Sync(); err != nil {
+ 		w.f.Close()
+ 		return err
+@@ -72,11 +76,22 @@ func (w *atomicFileWriter) Close() (retErr error) {
+ 	if err := w.f.Close(); err != nil {
+ 		return err
+ 	}
+-	if err := os.Chmod(w.f.Name(), w.perm); err != nil {
+-		return err
+-	}
+ 	if w.writeErr == nil {
+-		return os.Rename(w.f.Name(), w.fn)
++		if err := os.Rename(w.f.Name(), w.fn); err != nil {
++			return err
++		}
++
++		parentDir, err := os.OpenFile(filepath.Dir(w.fn), syscall.O_DIRECTORY, 0)
++		if err != nil {
++			return err
++		}
++
++		defer func() {
++			parentDir.Close()
++		}()
++		if err := parentDir.Sync(); err != nil {
++			return err
++		}
+ 	}
+ 	return nil
+ }
+-- 
+2.10.2
+

--- a/meta-resin-common/recipes-containers/docker/docker_git.bb
+++ b/meta-resin-common/recipes-containers/docker/docker_git.bb
@@ -33,6 +33,7 @@ SRC_URI = "\
   file://0005-Update-layer-store-to-sync-transaction-files-before-.patch \
   file://0006-Atomically-save-libtrust-key-file.patch \
   file://0009-graph-aufs-durably-write-layer-on-disk-before-return.patch \
+  file://0010-pkg-ioutils-sync-parent-directory-too.patch \
 	"
 
 # Apache-2.0 for docker

--- a/meta-resin-common/recipes-containers/docker/docker_git.bb
+++ b/meta-resin-common/recipes-containers/docker/docker_git.bb
@@ -32,6 +32,7 @@ SRC_URI = "\
   file://0004-Set-permission-on-atomic-file-write.patch \
   file://0005-Update-layer-store-to-sync-transaction-files-before-.patch \
   file://0006-Atomically-save-libtrust-key-file.patch \
+  file://0009-graph-aufs-durably-write-layer-on-disk-before-return.patch \
 	"
 
 # Apache-2.0 for docker


### PR DESCRIPTION
Before this patch a power failure or system crash right after a
`docker pull` would result in a corrupted /var/lib/docker

Signed-off-by: Petros Angelatos <petrosagg@gmail.com>