### PR TITLE
Fix tun rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Fix racing issue in between connman and openvpn related to tun device rename [Andrei]
 * Update supervisor to v2.8.2 [Pablo]
 * Update supervisor to v2.8.1 [Pablo]
 

--- a/meta-resin-common/recipes-connectivity/connman/resin-connman-conf/main.conf
+++ b/meta-resin-common/recipes-connectivity/connman/resin-connman-conf/main.conf
@@ -1,5 +1,5 @@
 [General]
 PreferredTechnologies=wifi,ethernet
 SingleConnectedTechnology=false
-NetworkInterfaceBlacklist=docker,veth,tun,p2p
+NetworkInterfaceBlacklist=docker,veth,tun,p2p,resin-vpn
 FallbackNameservers=8.8.8.8


### PR DESCRIPTION
Connects to https://github.com/resin-os/resinos/issues/123

This PR is 1.X specific as 2.X doesn't use connman anymore. NM masks devices by type.