### PR TITLE
docker-resin-supervisor-disk: Update supervisor to v2.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Update supervisor to v2.8.3 [Pablo]
 * Activate kernel configs for supporting iptables REJECT, MASQUERADE targets [Florin]
 * systemd: enable watchdog at 10 seconds [Florin]
 * Allow resin-init-flasher to also flash both MLO and regular u-boot at the same time [Florin]

--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
@@ -9,7 +9,7 @@ SUPERVISOR_REPOSITORY_x86 = "resin/i386-supervisor"
 SUPERVISOR_REPOSITORY_x86-64 = "resin/amd64-supervisor"
 
 TARGET_REPOSITORY ?= "${SUPERVISOR_REPOSITORY}"
-TARGET_TAG ?= "v2.8.2"
+TARGET_TAG ?= "v2.8.3"
 LED_FILE ?= "/dev/null"
 
 inherit systemd


### PR DESCRIPTION
Closes #484 