### PR TITLE
[1.X] docker-resin-supervisor-disk: Update supervisor to v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Update supervisor to v2.9.0 [Pablo]
 * Rewrite prepare-openvpn (style) and make it fail on error [Michal]
 * Ensure prepare-openvpn.service starts after var-volatile.mount [Michal]
 * kernel-modules-headers: specify cross compiler command [Florin]

--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
@@ -8,7 +8,7 @@ SUPERVISOR_REPOSITORY_aarch64 = "resin/armv7hf-supervisor"
 SUPERVISOR_REPOSITORY_x86 = "resin/i386-supervisor"
 SUPERVISOR_REPOSITORY_x86-64 = "resin/amd64-supervisor"
 
-SUPERVISOR_TAG ?= "v2.8.3"
+SUPERVISOR_TAG ?= "v2.9.0"
 TARGET_REPOSITORY ?= "${SUPERVISOR_REPOSITORY}"
 TARGET_TAG ?= "${SUPERVISOR_TAG}"
 LED_FILE ?= "/dev/null"


### PR DESCRIPTION
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>
Connects to #526 