### PR TITLE
resin-mounts-flasher: don't make temp-conf.service depend on defaults

### DIFF
--- a/meta-resin-common/recipes-support/resin-mounts/resin-mounts-flasher/temp-conf.service
+++ b/meta-resin-common/recipes-support/resin-mounts/resin-mounts-flasher/temp-conf.service
@@ -2,6 +2,7 @@
 Description=Temporary resin config in /tmp/conf
 Requires=mnt-bootorig.mount tmp.mount
 After=mnt-bootorig.mount tmp.mount
+DefaultDependencies=no
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
All .services by default depend on basic.target. This is unneeded for
this simple service, and created a dependency cycle.