### PR TITLE
[master] Do not remove the supervisor container before every start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Remove the supervisor container in the update script [Pablo]
 * Do not remove the supervisor container in every start [Pablo]
 * Update supervisor to v3.0.0 [Pablo]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Do not remove the supervisor container in every start [Pablo]
 * Update supervisor to v3.0.0 [Pablo]
 
 # v2.0-beta.8 - 2017-01-27

--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
@@ -17,6 +17,7 @@ inherit systemd
 
 SRC_URI += " \
     file://resin-data.mount \
+    file://start-resin-supervisor \
     file://supervisor.conf \
     file://resin-supervisor.service \
     file://update-resin-supervisor \
@@ -107,6 +108,7 @@ do_install () {
 
     install -d ${D}${bindir}
     install -m 0755 ${WORKDIR}/update-resin-supervisor ${D}${bindir}
+    install -m 0755 ${WORKDIR}/start-resin-supervisor ${D}${bindir}
 
     if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
         install -d ${D}${systemd_unitdir}/system

--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/resin-supervisor.service
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/resin-supervisor.service
@@ -20,32 +20,8 @@ RestartSec=10s
 EnvironmentFile=/etc/resin-supervisor/supervisor.conf
 EnvironmentFile=-/tmp/update-supervisor.conf
 ExecStartPre=-@BINDIR@/docker stop resin_supervisor
-ExecStartPre=-@BINDIR@/docker rm --force resin_supervisor
-ExecStart=@BASE_BINDIR@/bash -c 'source @SBINDIR@/resin-vars && \
-    @BINDIR@/docker run --privileged --name resin_supervisor \
-    --net=host \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    -v $CONFIG_PATH:/boot/config.json  \
-    -v /mnt/data/apps.json:/boot/apps.json \
-    -v /resin-data/resin-supervisor:/data \
-    -v /proc/net/fib_trie:/mnt/fib_trie \
-    -v /var/log/supervisor-log:/var/log \
-    -v /:/mnt/root \
-    -e DOCKER_ROOT=/mnt/root/var/lib/docker \
-    -e DOCKER_SOCKET=/var/run/docker.sock \
-    -e BOOT_MOUNTPOINT=$BOOT_MOUNTPOINT \
-    -e API_ENDPOINT=$API_ENDPOINT \
-    -e REGISTRY_ENDPOINT=$REGISTRY_ENDPOINT \
-    -e PUBNUB_SUBSCRIBE_KEY=$PUBNUB_SUBSCRIBE_KEY \
-    -e PUBNUB_PUBLISH_KEY=$PUBNUB_PUBLISH_KEY \
-    -e MIXPANEL_TOKEN=$MIXPANEL_TOKEN \
-    -e DELTA_ENDPOINT=$DELTA_ENDPOINT \
-    -e LED_FILE=${LED_FILE} \
-    -e LISTEN_PORT=$LISTEN_PORT \
-    -e SUPERVISOR_IMAGE=${SUPERVISOR_IMAGE} \
-    ${SUPERVISOR_IMAGE}'
+ExecStart=@BINDIR@/start-resin-supervisor
 ExecStop=-@BINDIR@/docker stop resin_supervisor
-ExecStop=-@BINDIR@/docker rm --force resin_supervisor
 
 [Install]
 WantedBy=multi-user.target

--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/start-resin-supervisor
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/start-resin-supervisor
@@ -1,0 +1,34 @@
+#!/bin/sh -e
+
+source /usr/sbin/resin-vars
+
+SUPERVISOR_IMAGE_ID=$(docker inspect --format='{{.Id}}' $SUPERVISOR_IMAGE)
+SUPERVISOR_CONTAINER_IMAGE_ID=$(docker inspect --format='{{.Image}}' resin_supervisor || echo "")
+
+runSupervisor() {
+    docker rm --force resin_supervisor || true
+    docker run --privileged --name resin_supervisor \
+        --net=host \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        -v $CONFIG_PATH:/boot/config.json  \
+        -v /mnt/data/apps.json:/boot/apps.json \
+        -v /resin-data/resin-supervisor:/data \
+        -v /proc/net/fib_trie:/mnt/fib_trie \
+        -v /var/log/supervisor-log:/var/log \
+        -v /:/mnt/root \
+        -e DOCKER_ROOT=/mnt/root/var/lib/docker \
+        -e DOCKER_SOCKET=/var/run/docker.sock \
+        -e BOOT_MOUNTPOINT=$BOOT_MOUNTPOINT \
+        -e API_ENDPOINT=$API_ENDPOINT \
+        -e REGISTRY_ENDPOINT=$REGISTRY_ENDPOINT \
+        -e PUBNUB_SUBSCRIBE_KEY=$PUBNUB_SUBSCRIBE_KEY \
+        -e PUBNUB_PUBLISH_KEY=$PUBNUB_PUBLISH_KEY \
+        -e MIXPANEL_TOKEN=$MIXPANEL_TOKEN \
+        -e DELTA_ENDPOINT=$DELTA_ENDPOINT \
+        -e LED_FILE=${LED_FILE} \
+        -e LISTEN_PORT=$LISTEN_PORT \
+        -e SUPERVISOR_IMAGE=${SUPERVISOR_IMAGE} \
+        ${SUPERVISOR_IMAGE}
+}
+
+([ "$SUPERVISOR_IMAGE_ID" == "$SUPERVISOR_CONTAINER_IMAGE_ID" ] && docker start --attach resin_supervisor) || runSupervisor

--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/update-resin-supervisor
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/update-resin-supervisor
@@ -134,12 +134,14 @@ fi
 echo "Stop supervisor..."
 systemctl stop resin-supervisor
 
-# Store the tagged image string so resin-supervisor.service can pick it up
-echo "SUPERVISOR_IMAGE=$image_name:$tag" > $UPDATECONF
-
 # Pull target version.
 echo "Pulling supervisor $image_name:$tag..."
 $DOCKER pull "$image_name:$tag"
+
+$DOCKER rm --force resin_supervisor || true
+
+# Store the tagged image string so resin-supervisor.service can pick it up
+echo "SUPERVISOR_IMAGE=$image_name:$tag" > $UPDATECONF
 
 # Run supervisor with the device-type-specific options.
 # We give a specific name to the container to guarantee only one running.


### PR DESCRIPTION
[Untested, this is my first attempt]
Instead, we add a start-resin-supervisor script that checks
whether the existing container's image matches the one specified
in supervisor.conf, and just starts that container in that case.
It falls back to the docker run command that creates and starts
the supervisor container.

We also add the container removal in the update-resin-supervisor script,
after stopping the resin-supervisor service.

Closes #184 
Also connects to #280 as it should make the issue appear way less often.

Signed-off-by: Pablo Carranza Velez <pablo@resin.io>