### PR TITLE
Follow up commits on the 1.X for when an 1.X boards is actually switched to using morty

### DIFF
--- a/meta-resin-common/classes/kernel-resin.bbclass
+++ b/meta-resin-common/classes/kernel-resin.bbclass
@@ -322,7 +322,7 @@ def appendLineToFile (filepath, line):
 # Inject resin configs
 #
 python do_kernel_resin_injectconfig() {
-    activatedflags = d.getVar("RESIN_CONFIGS").split()
+    activatedflags = d.getVar("RESIN_CONFIGS", True).split()
     if not activatedflags:
         bb.warn("No resin specific kernel configuration flags selected.")
         return
@@ -385,7 +385,7 @@ do_kernel_resin_reconfigure[dirs] += "${B}"
 # Check that all the wanted configs got activated in kernel
 #
 python do_kernel_resin_checkconfig() {
-    activatedflags = d.getVar("RESIN_CONFIGS").split()
+    activatedflags = d.getVar("RESIN_CONFIGS", True).split()
     if not activatedflags:
         bb.warn("No resin specific kernel configuration flags selected.")
         return

--- a/meta-resin-common/recipes-connectivity/connman/connman/unprotected_wifi_tether_updated_for_morty.patch
+++ b/meta-resin-common/recipes-connectivity/connman/connman/unprotected_wifi_tether_updated_for_morty.patch
@@ -1,0 +1,28 @@
+Because connman does not want to have unprotected tethering.
+
+Upstream-Status: Denied
+
+Signed-off-by: Florin Sarbu <florin@resin.io>
+
+Index: connman-1.33/src/technology.c
+===================================================================
+--- connman-1.33.orig/src/technology.c
++++ connman-1.33/src/technology.c
+@@ -249,7 +249,7 @@ static int set_tethering(struct connman_
+ 		return -EOPNOTSUPP;
+ 
+ 	if (technology->type == CONNMAN_SERVICE_TYPE_WIFI &&
+-	    (!ident || !passphrase))
++	    (!ident))
+ 		return -EINVAL;
+ 
+ 	for (tech_drivers = technology->driver_list; tech_drivers;
+@@ -925,7 +925,7 @@ static DBusMessage *set_property(DBusCon
+ 
+ 		err = __connman_service_check_passphrase(CONNMAN_SERVICE_SECURITY_PSK,
+ 							str);
+-		if (err < 0)
++		if (str != NULL && err < 0)
+ 			return __connman_error_passphrase_required(msg);
+ 
+ 		if (g_strcmp0(technology->tethering_passphrase, str) != 0) {

--- a/meta-resin-common/recipes-connectivity/connman/connman/write_dns_to_resolv.dnsmasq_updated_for_morty.patch
+++ b/meta-resin-common/recipes-connectivity/connman/connman/write_dns_to_resolv.dnsmasq_updated_for_morty.patch
@@ -1,0 +1,13 @@
+Index: connman/src/resolver.c
+===================================================================
+--- connman.orig/src/resolver.c
++++ connman/src/resolver.c
+@@ -133,7 +133,7 @@ static int resolvfile_export(void)
+ 
+ 	old_umask = umask(022);
+ 
+-	fd = open(RESOLV_CONF_STATEDIR, O_RDWR | O_CREAT | O_CLOEXEC,
++	fd = open("/etc/resolv.dnsmasq", O_RDWR | O_CREAT | O_CLOEXEC,
+ 					S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+ 	if (fd < 0) {
+ 		connman_warn_once("Cannot create "RESOLV_CONF_STATEDIR" "

--- a/meta-resin-common/recipes-connectivity/connman/connman_%.bbappend
+++ b/meta-resin-common/recipes-connectivity/connman/connman_%.bbappend
@@ -2,7 +2,6 @@ FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
 SRC_URI_append = " \
     file://allow_more_than_MAXNS_nameserver_entries_in_the_resolv_file.patch \
     file://do_not_add_routes_to_nameservers.patch \
-    file://remove-old-IP-and-gateway-address.patch \
     "
 
 # starting with connman version 1.32, the patch unprotected_wifi_tether.patch needs to be redone
@@ -25,6 +24,14 @@ python() {
         d.setVar('SRC_URI', srcURI + ' ' + 'file://write_dns_to_resolv.dnsmasq_updated_for_morty.patch')
     else:
         d.setVar('SRC_URI', srcURI + ' ' + 'file://write_dns_to_resolv.dnsmasq.patch')
+}
+
+# for connman versions older than 1.33 we still need to apply the folowing patch:
+python() {
+    packageVersion = d.getVar('PV', True)
+    srcURI = d.getVar('SRC_URI', True)
+    if packageVersion < '1.33':
+        d.setVar('SRC_URI', srcURI + ' ' + 'file://remove-old-IP-and-gateway-address.patch')
 }
 
 PR = "${INC_PR}.4"

--- a/meta-resin-common/recipes-connectivity/connman/connman_%.bbappend
+++ b/meta-resin-common/recipes-connectivity/connman/connman_%.bbappend
@@ -1,6 +1,5 @@
 FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
 SRC_URI_append = " \
-    file://write_dns_to_resolv.dnsmasq.patch \
     file://allow_more_than_MAXNS_nameserver_entries_in_the_resolv_file.patch \
     file://do_not_add_routes_to_nameservers.patch \
     file://remove-old-IP-and-gateway-address.patch \
@@ -15,6 +14,17 @@ python() {
         d.setVar('SRC_URI', srcURI + ' ' + 'file://unprotected_wifi_tether_updated_for_morty.patch')
     else:
         d.setVar('SRC_URI', srcURI + ' ' + 'file://unprotected_wifi_tether.patch')
+}
+
+# starting with connman version 1.31, the patch write_dns_to_resolv.dnsmasq.patch needs to be redone
+# we work around this by detecting the connman version and applying the right patch for it
+python() {
+    packageVersion = d.getVar('PV', True)
+    srcURI = d.getVar('SRC_URI', True)
+    if packageVersion >= '1.31':
+        d.setVar('SRC_URI', srcURI + ' ' + 'file://write_dns_to_resolv.dnsmasq_updated_for_morty.patch')
+    else:
+        d.setVar('SRC_URI', srcURI + ' ' + 'file://write_dns_to_resolv.dnsmasq.patch')
 }
 
 PR = "${INC_PR}.4"

--- a/meta-resin-common/recipes-connectivity/connman/connman_%.bbappend
+++ b/meta-resin-common/recipes-connectivity/connman/connman_%.bbappend
@@ -1,11 +1,21 @@
 FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
 SRC_URI_append = " \
-    file://unprotected_wifi_tether.patch \
     file://write_dns_to_resolv.dnsmasq.patch \
     file://allow_more_than_MAXNS_nameserver_entries_in_the_resolv_file.patch \
     file://do_not_add_routes_to_nameservers.patch \
     file://remove-old-IP-and-gateway-address.patch \
     "
+
+# starting with connman version 1.32, the patch unprotected_wifi_tether.patch needs to be redone
+# we work around this by detecting the connman version and applying the right patch for it
+python() {
+    packageVersion = d.getVar('PV', True)
+    srcURI = d.getVar('SRC_URI', True)
+    if packageVersion >= '1.32':
+        d.setVar('SRC_URI', srcURI + ' ' + 'file://unprotected_wifi_tether_updated_for_morty.patch')
+    else:
+        d.setVar('SRC_URI', srcURI + ' ' + 'file://unprotected_wifi_tether.patch')
+}
 
 PR = "${INC_PR}.4"
 

--- a/meta-resin-common/recipes-containers/docker/docker/0011-fix-compilation-errors-with-btrfs-progs-4.5.patch
+++ b/meta-resin-common/recipes-containers/docker/docker/0011-fix-compilation-errors-with-btrfs-progs-4.5.patch
@@ -1,0 +1,50 @@
+From a038cccf88998814249a7a40b71a33a680e3f02f Mon Sep 17 00:00:00 2001
+From: Julio Montes <imc.coder@gmail.com>
+Date: Fri, 1 Apr 2016 08:58:29 -0600
+Subject: [PATCH] Fix compilation errors with btrfs-progs-4.5
+
+btrfs-progs-4.5 introduces device delete by devid
+for this reason btrfs_ioctl_vol_args_v2's name was encapsulated
+in a union
+
+this patch is for setting btrfs_ioctl_vol_args_v2's name
+using a C function in order to preserve compatibility
+with all btrfs-progs versions
+
+Signed-off-by: Julio Montes <imc.coder@gmail.com>
+
+Upstream-Status: Backport
+Signed-off-by: Florin Sarbu <florin@resin.io>
+---
+ daemon/graphdriver/btrfs/btrfs.go | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/daemon/graphdriver/btrfs/btrfs.go b/daemon/graphdriver/btrfs/btrfs.go
+index 9d69474..128a807 100644
+--- a/daemon/graphdriver/btrfs/btrfs.go
++++ b/daemon/graphdriver/btrfs/btrfs.go
+@@ -7,6 +7,10 @@ package btrfs
+ #include <dirent.h>
+ #include <btrfs/ioctl.h>
+ #include <btrfs/ctree.h>
++
++static void set_name_btrfs_ioctl_vol_args_v2(struct btrfs_ioctl_vol_args_v2* btrfs_struct, const char* value) {
++    snprintf(btrfs_struct->name, BTRFS_SUBVOL_NAME_MAX, "%s", value);
++}
+ */
+ import "C"
+ 
+@@ -159,9 +163,10 @@ func subvolSnapshot(src, dest, name string) error {
+ 
+ 	var args C.struct_btrfs_ioctl_vol_args_v2
+ 	args.fd = C.__s64(getDirFd(srcDir))
+-	for i, c := range []byte(name) {
+-		args.name[i] = C.char(c)
+-	}
++
++	var cs = C.CString(name)
++	C.set_name_btrfs_ioctl_vol_args_v2(&args, cs)
++	C.free(unsafe.Pointer(cs))
+ 
+ 	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, getDirFd(destDir), C.BTRFS_IOC_SNAP_CREATE_V2,
+ 		uintptr(unsafe.Pointer(&args)))

--- a/meta-resin-common/recipes-containers/docker/docker_git.bb
+++ b/meta-resin-common/recipes-containers/docker/docker_git.bb
@@ -35,7 +35,8 @@ SRC_URI = "\
   file://0008-daemon-cleanup-as-early-as-possible.patch \
   file://0009-graph-aufs-durably-write-layer-on-disk-before-return.patch \
   file://0010-pkg-ioutils-sync-parent-directory-too.patch \
-	"
+  file://0011-fix-compilation-errors-with-btrfs-progs-4.5.patch \
+"
 
 # Apache-2.0 for docker
 LICENSE = "Apache-2.0"

--- a/meta-resin-common/recipes-devtools/btrfs-tools/btrfs-tools_%.bbappend
+++ b/meta-resin-common/recipes-devtools/btrfs-tools/btrfs-tools_%.bbappend
@@ -1,2 +1,9 @@
 FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
-SRC_URI_append = " file://0001-btrfs-progs-utils-make-sure-set_label_mounted-uses-c.patch"
+
+# for btrfs-tools older than 4.6 we still need to apply the folowing patch:
+python() {
+    packageVersion = d.getVar('PV', True)
+    srcURI = d.getVar('SRC_URI', True)
+    if packageVersion < '4.6':
+        d.setVar('SRC_URI', srcURI + ' ' + 'file://0001-btrfs-progs-utils-make-sure-set_label_mounted-uses-c.patch')
+}

--- a/meta-resin-morty/recipes-kernel/linux-firmware/files/0001-Revert-rt2870sta-Update-rt3071.bin-to-match-rt2870.b.patch
+++ b/meta-resin-morty/recipes-kernel/linux-firmware/files/0001-Revert-rt2870sta-Update-rt3071.bin-to-match-rt2870.b.patch
@@ -1,0 +1,61 @@
+From c0b7f8a68aeaf69891de3ba3c0eeed03dc28bbcd Mon Sep 17 00:00:00 2001
+From: Florin Sarbu <florin@resin.io>
+Date: Wed, 25 Jan 2017 15:40:33 +0100
+Subject: [PATCH 1/2] Revert "rt2870sta: Update rt3071.bin to match rt2870.bin"
+
+This reverts commit 9564a7916109033fbf87a532d96c39aef8637f3c.
+---
+ rt3071.bin | Bin 4096 -> 4096 bytes
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+
+diff --git a/rt3071.bin b/rt3071.bin
+index df12e5fd9f013d8165b3ab271088069f96b6e62f..b1f44e0207aef4728ec0d401a499512f048a0b7b 100644
+GIT binary patch
+delta 1119
+zcmb_aTWHfz7*0;oIG5F?X_}~OF&1s+RGQ7<x~W5Vv15q4bsMNik>QI9nYJ%p<8)7g
+zMvsah!^=QW&?#Q_;Dgc)!541>5uXmT5mdyW3;1H=Nvl|W_TilT|M!3S{>%AwS(j@Z
+z#{paw;A#PP2n1JwU>y)iATqoNBA~JzgmwYx91vfq9!B<3e7Ng$W8dytL*tR%Z_qU2
+z%O7wbYq)2t{edojN4LMX$KTuQ?@jv8_W9rS^BV^FJsN*uh<~y-aByGXN?N#}3l9y!
+zI!zEkEaOM^+MJ;UEQ1!(x@GpyY7_|8g5Yu)P%0HZ1mH6u(JlZ*at*1#9x_pMN68d+
+z^Q4UL+l&xZblOyA9RpN-Db+DF4%yY2byTKlQO=G*L<gncIow#@E#k-L@9*sac$Azk
+zx~WQVd-&urR16i<egH#lIeW9+nQ3$~Yn__|<NZ8)!_ex|HP%=<YGuWoz0KZYZ#6X4
+z8nf)`tW@l+&}K=4@D8=ODEXRNywEWRrZ25;HndgdfaT_Qu!%4<1W(e@&~w)lEPd)9
+z!sMl{m`j*jAkdfqPteQA=kPxLRte6S)o!aZ>B~!F_HeFllYI=O_8&RSixXdx`Bw15
+zHAmqCj|{{K_{I~B;6N)?giC(PS)P~~yH`fJ1FUD{V77TWq6(^^EkJz=u5>=?v<t7`
+zDZB!F%3NPAekCNGmJXIl+c=4lrD#g3zf2I)@JM^hNJsO?rtM~8kV#QM8iu2DuF(Nr
+znz)-Nv&crp0LxG^Z<#GqNuQ9aSdzzw(gNAI?t2y2S#zU0Lrv@C<e9jd@Qf><((ArF
+z{=lK~0Jrb}-T|a0C`Sjg&M5_+Ess$R**JVsUeyxMHt2yr0vOimEC$sCJ^pKhT)D(x
+zMQSd-SzKQw|Bqe`yK-KG-dLgnceCO82HjTz>EJKX!dgbm#66ZPboa?JmE@<kHaxb+
+zY&F|1q;@U=I9aF@+HAC?$>3;|{AOjkNer1?8k5=K1`VD-NlN37$b4m!0j{FtBg_Fs
+z4kmOMU<|46v9%EnR$L@QXS{Mn$n3#Wq_KK<0bJqjCTHMbZ;TAVTi){^5`iy$D<JZP
+N|JPv%f(Rea{sh7rqyhi{
+
+delta 1629
+zcmZ`(Z)_Ar6z|T?{p(%RyXpOdJG^C6S~vsUTCLhMp^=s=xX?Sewh1<5CDnxJhXq<S
+z>Uk4L{bGz$7L1XYqD@E?6$_=5RKQ%LUrda-CXo2W(cGFKhOU8)F$(AG-Zd1AUuNF#
+zy*I!2CvP4Wu+UYhRDgdy@TY+PEf6{YLI**35QHaDct`}XpTU}X5ZweK`z41{XyDPB
+zCCTL!8hP|k&qVt`pGs6j%|QYoMfJ1(TkZa9oq>2Jusa(V-W3?$9T?69J{$=AK8Vhb
+zpzY72*Iz)_4>nC7YPvcayo!T=k<g}zy1I}$@qHAkAhdttw}gFb4P1&#YTLMU6&~Xh
+z22D;VBnj9+D@0vI?=J0SvLU76nIwjK@^*!Q^-G36cw6N`$YLX^pEezh72}@|of$;l
+zPYDc;Vnd2KORmyB42t{8L~Xk7fjmu#eAyuK9J{X=Wg<^AaFKyI!zR%NKoBi+o0}C_
+zCDPJBtY-QxI50Gpik8h5v$Ys6#>|~&|5#UL?5WCf5^CpYw=p&Pm_Z;%dpM&QE}O&V
+z9`jkEO2(97ZZ1Zui9VQ}_6EPU8ssB>?YdmSpcQ>+ak6_0Q9JY@!>X1wrh_g_E*^v3
+zhiLOZhL(XXLLXjO_UN!Y{522Ba&CsU6W@ow)^@-RT%Yy|{INAG=$ly=!@}svb#3P1
+z@}shOgetEU-b9hiQtoaKxMPW(+N%x$L^9e3j+O#5^zc>nibrL`(WbY}IQg>Krl%Ab
+zN@0F1byrWRZo%b{VxZ*GcdM%<#dCItv;#V}7NOqXyHj!N{h@x==bfUcw>RHZ8iR^I
+zsGw%3Mp5_(4i$TGplq(izLKX@U-FiGG6sv{f=D2sJ#J(C$;0DM9ML-r{gElwXFzj*
+z8ln_r6|bTLN!EiX?Kl5_lr+it$-|Mi>!Pb*G~|w${>Y>dxuQgVI9XR0jg9wh8Q=c&
+zxV%?Sk2n<`L}MCsor0gCXy)7(E`wu}I_Zh_WN>3CgT4Az=@)(xa|=f^QrdAQ31X+L
+zS+%b8h)Zc?r(5x`)5EA@K{mrwO7j&AZdcw-YJYp$_-rwwZLD9vB~#4erh9ZujbV`~
+zSNwn~tIy{1T70J;;CsJ*qd$wgR<PiWT33DS@hom!sRZ}Y+8;~Q(=%Sb_5E@;3_Y2<
+z(c5b#wN`J^`%F-IsTr_v@tfMPw`JQk;)gVM%NWaYOr>XR%h*24PEZ}q@hU0^D0Yp2
+zk7@1-a|8F>K>RuZQ&jqudF$FY-V@xs_MA`f&Fi~@iVrfXHFMfKzAT5epL}i1*x2x1
+zL5T0kJ5XYr$X}ww%S4`EGV;8Qzq0WqhCL`jh<t%bZd;mVk_#nH6Zt%ooVGNxbpMwx
+z#fvU6&lTp_tQRg?vp>SI3=%Ic68RiG-b&=N^mt2mA;9(oh4$J|R@0z?L)Ox$SZicq
+zGUHy}AofzoJ8U{T)f0J81M?_xBG1<VOL{5~Yv7UvJT-6uC1&&P8kn_!i-AI<lT|_Q
+zSSfbqoi+2!vVud2%jG-lz-~vY-l_se3oDBiT@7v*CfbkwBi1Oy<$HzK3YC{d<?P_1
+Ns7*Jt^UZ&J_b*5DfJp!V
+
+-- 
+2.7.4
+

--- a/meta-resin-morty/recipes-kernel/linux-firmware/files/0002-Revert-linux-firmware-update-rt2870.bin-rt2800usb-dr.patch
+++ b/meta-resin-morty/recipes-kernel/linux-firmware/files/0002-Revert-linux-firmware-update-rt2870.bin-rt2800usb-dr.patch
@@ -1,0 +1,118 @@
+From 8245054a622c2e89a28abed69662117ad3c7e803 Mon Sep 17 00:00:00 2001
+From: Florin Sarbu <florin@resin.io>
+Date: Wed, 25 Jan 2017 15:40:47 +0100
+Subject: [PATCH 2/2] Revert "linux-firmware: update rt2870.bin, rt2800usb
+ driver"
+
+This reverts commit 9023bf7dc753c99ea29be742fe4f09d455f379ba.
+---
+ WHENCE     |   4 +---
+ rt2870.bin | Bin 8192 -> 8192 bytes
+ 2 files changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/WHENCE b/WHENCE
+index 952ba9c..45cda00 100644
+--- a/WHENCE
++++ b/WHENCE
+@@ -1425,12 +1425,10 @@ Licence: Redistributable. See LICENCE.ralink-firmware.txt for details
+ Driver: rt2800usb - Ralink RT2870, RT3070, RT3071, RT3072, RT5370 wireless MACs
+ 
+ File: rt2870.bin
+-Version: 36
+ 
+ Licence: Redistributable. See LICENCE.ralink-firmware.txt for details
+ 
+-Binary file supplied originally by Shiang Tu <shiang_tu@ralinktech.com>, latest
+-from http://www.mediatek.com/en/downloads1/downloads/
++Binary file supplied by Shiang Tu <shiang_tu@ralinktech.com>. Firmware Version 29
+ 
+ --------------------------------------------------------------------------
+ 
+diff --git a/rt2870.bin b/rt2870.bin
+index 9ddac4a4bb190770789b1fbd7e28cea0a6349854..f1535d1eced0844d0aba9e65d188f769624c9fa4 100644
+GIT binary patch
+delta 2149
+zcmchXe`p(J7{_z(U1HZX_I~BAO)e~rTheuNNq?}WaV@n!mQsgJ+q4xO8l*VNCS11U
+zA6>Vzv;U~fYu`DC8n#&!6toVv7A82!#z2HkEy(b%qvj?$WT*B(gf+f*S-Uh&r^5W>
+zF7Nw1-}^rIJa6tJwM*^w`FtLbwSa5@<T!8w;KYH`2b=-g`G60&#(?`3z|8^Y&mpVL
+z>%eItITaZi!(@?G^kJDG6uLY^eqT?1v5g{QRJ5Op4N$Q`Di)`vhA3s2ZWHOTB>nn6
+z=8^r3m|}NJ>`O9xe#&BTA`eQ@x94P$(PV;6Nt!ymB%<mVV1M@lJcN730lW-&!U#YP
+zdk71_0W4bBX0Qa>E@NJF|H#Jr0}`PImhv*Fy;1BVi=?t_6uSA-Z`bq@_yShN8Foc+
+zed5SrrI0FE{{WJmIsH++FCEFJx92|?nH{F>Q?l5Us@G;xel5%8^j-Sn`V+Dk(q^<Q
+zUwC`7k)jshX}qRj_zhm;%Bv#_C)zt?u~8k-jOux`R8S}hj}U(0oUvmy>0*iC!iiYW
+z5Ueu=1QNiPiA~r!c$WAShHdMe*^UKYhz-eNwK5byo>fYpZcfB%P6U2#dv7zxSh!OJ
+zmnq}MNiN{!q6zM?lNJj%GuhKQ+1oL>^GP*2YD?gNn}M18-m$uxXzuFA(J~E-1Z1#D
+zi7#tv=f!v>o2b~Zj4oVcvSF$6>#$^3cZ3%41qr(_9S%jUvjO1RY8(Ulfyr`)tbPj}
+zh!Tq8c?m4#Uk$*c<w3k98-|z4Ydgc)7KyoSfWi`yMZr*%n7wtJhFx^DBC!tL?dSzv
+zjU|5d_6P58ks?JdaIf9d+#*#Lg(R@X)clY5)aV&IX?AyAQv>nq-Q8$zpV{l|J#6Bc
+z4FDB$i%_?3>~cLNlY|ogRZI6{D5l0lTl#4uE7KMwj*IjmFO4+dZ6$slX+S}P1bbvK
+zqlB)Z)owUi@dglDryc7ZLaRD}21%d-LIiGc^ka+gpkph_!VewCfX@fNs@wvVO3(jv
+z@lBp=cr64PfwKvq&xEtl9Pj~m4-obM{x!gTc?$xb7>tlZdmD-=Fh~AaPhQ?eF)^yQ
+zpBfyX1_!CZICXT0`fiwhc$9utq>m@*OZ%7u`<YWI_PE4;BD0zS0%UV%5HtYi=G!2k
+zdBO;+fPjh?wi(I<0rfW^Fdj2LIlV63il^Jw=ky>{SSN45W+k@<5>ype5?_S`RaGd9
+zAkqCNNWA}-kkISygbA~s(@agl@*iO0%H1$w3RW?31)gQU4LBFoI-}La)X9xOeInPi
+zQ$MUEo;!4q=H_q2m%G4CW0`?-RxjY@;Z>{OhZ0?QAzbuOPO}Ep;F&Vq7+|x_dw2M7
+z2tL19c!}T-l<~Vr-sa`~3BDP@ho2~g4?lt6^De>A{QQ4pkK19g$L%oL<9fb?75|n!
+z$gY?@Zo0(pUb08%L+tT)wiTgA=vzUL&{u>WcUuv9Obr4{?+SW^9SA*dV#2h;TOq81
+W$5Xum9#0Sx?h$uv7K_F6V)hS!`6%E3
+
+literal 8192
+zcmeHMeQXrR6~Fzs^Z5gOw|D0|b2dJ<XFg1^HzA>^O~ApQfit#Y@fk3%b=@i?plrxp
+zqO>x%g*bn-m9lY2{)r+YTWTxP$PK*^qBIb#qo`8)N42O)|EV;<O{z2vo)%VZ(%9EG
+zd*}KbVoDU+MyioK^WK~H-n^N8GxL5&Hk)NVt65JI>v@6=Jj4c$uoZo5#Yv$eF0$c^
+zY;_46s%L`-C8sO0gcGW#q#{?OoD-I}iaPUSBwdc+ehGPSOhSCBSz}WU-P15dU@YM#
+z8J+nlC6R=xbVfsIHZYFTj7Mi4N9i9FQzeE7OMWftydOpW$gu%cR|RDC={%2wlIJ~F
+zZ}Ysj!CTei-P!9M*x?=6=^c>0&+qd7xledyNZ9%v;rrheJ~-lg`C;F?3IDsA|6@H+
+z|CGZ)-FT6;F{7(K0=^R(!F|_M>Yoi9jIf-<RS&ZheM0F|xlvoOKxL%w9+MSy)q~_z
+z_I$|_>MreeCATxl?#E}vtU$#>ZiPqb2#j&b?nuU}12Zp*W=A_<RXnOi(S25&nq(6l
+zwei2dJ@qyn&n7x^OlJB9Vc?FTBBdHyw-SW5Sn)zzqLe~gsyJ~+y39?T$>mlfFvV`%
+znC7^Q)ecMvWf;ojXE1p?uxnWw%K>P;Xjfggu7(IDb+wY@6{P@g`n8oXf~-27U4uZk
+z63tBQ2bxG7{6w9`<2vxeuAVB~R_fO`8aAq4iWe+N3cJiAb5LWA!Ow289(x(-v2#R^
+zorV59WJ~O2U|s{}EScxzI!l<!+N|(7zsb9~<ffX8)o^1Qj{{lpjMZ=L);%0buXZN;
+z8EvCYOF*-lWYg<`=C!Cz-&v-6Sd=~jBDdzviArqI(_FIO1DSuZQg^yhD?_GrrxVHl
+zAgw(4NS*;9Nj8Nt)=F!YQDua!?N)cPF`L|&osCi5kZ303i8~=Z8ES7-WUK*ekF{4<
+zB{EK|%|`I^Q<H8pWY^O-OdK5+t9!mq;4H#4c8;X1IFdD8y&YJZ)&ym7{KCoR7F}JB
+z<F*h!^m;UT^1=ze`C%0O6f{5`b?Z(C!ToZ%!l#08z`eSYnS#(6lHf>ISW>4=&bnAn
+zEj)P_67?44Z`#Y7)b!?NEL>h{Hg5~I%RafVNn1_l?0(yqz-%5Vk7;UtA1mnQSOfFa
+z;1l3IWE}4$ncNrg(L7gLwI-?zeuLE5+BeTg3i=AdLNc-9ZTldn;Rd3{MY>u`zq2Uf
+zO>K88C3sU{lUfqETXW^o*Oqc@MFek#d#WOmc%inzI+nR3W*tY$_fkiNV9%61)5=a$
+zaszHiIcnidMjh6%MAxQ?V|wgoWPA$Z?X%*k6exoLeKL+}<JPf1-PvaypCZmUj;pM*
+zZ}NnO`%W;;zt1^s<#H|yCd?3L18zvW;Pz<1O$r}q(zs;P3~o~0ks_xQX3ZkJQ(Y!0
+z#izTZF5cO0@VL8eyW+;(fo`~Ax5FZDi(XO6{ffu02vJ@Q2^Gh+fYGLTGu8^N%q%ub
+z%u=&VV=su4a80tP)lEjed2Hma<9I#6w~xcAV3GVcB1(Qpqe{4`ATdIy``=$khF_{s
+zj0xSt!)b>r3dv3@jt7Pqbp?)tR6;I#Of??CNyTyL(rwPYc(1zFxkp<CEDGZR&{7MO
+z?D0|<FQQJt%A62&Pt`|szsD0LaK@^T)vtS&qsYapFj7s$rSruT{i3nWh~ZXv)Pg^9
+zgev(^z#X(a!IP2Tc_sMU7aWdIc%-vsWb2lZ*nYU)T?)sB!de)2z6G~?3*Jh*EjUIy
+zdtCk2&X#g*VC3GGk!@Q>x^l8EFt|5ouq|iMHD@5<7P-9DW3^~2VFKQMKb)?X{d{su
+zF+3P9k3BBIxXaw8v1Tk|)#5F0$s|h$x~&7IBANl*5w(=k=sQYLv{`i-0Z|D5TnP0T
+z0b|18VP|0L;VqY!!sQ&&+<1FiH=LJ{X-mg4qm_x}1RsD!ti!dcPYOBlfe0>@Dl0)K
+zWzS1q5Id8#kQsqm^N@L1E5`?<_gw}hdGnBQ7((aN71FkxC<N-96!XH?+IB^=cJw*)
+z<JQRKQrtMi!dl^F<f#|>H2Ub%m~#NHq-y((94x~7BZxhHU*rKwU1U$+A302^OYG@G
+z$@=EVL4NE$ZKZUd3%8G5(yFO8pJHgmgWF{?bB^#wfjjEB@*u4E;n5?J2l%o3!QlQm
+zgNq9rBu5jG!~EDG`{R_TqI8IwUDkqjtTuTEZjWR*33C@TW)d9R8o5X=E$sNAQFZQK
+z;?U#?skssj-LCk@9vXdgOdWj$*ZX|(W~<(K)O<t=F4<X6aDCf8csYpXf))c0`KWf#
+z!z6WZS&hAxebO!r<QalnAi?}fS#$>eIMrwLXys;)R*KuDOLm;2JyM5rqK*y!gw_nS
+zqcu%Av~C5`4r&^X4f{XG_ooCm`W4Zy)cTcm(NC3oqaQ2&=u))@x6^o&gnJy5XjW@9
+zdtuT|`3b8hwPloCBHslo?QtD-z$fCNbzGr|*kkl+zPZ?_C2xSRpsdM-SY`)TN`rgx
+zbAp?;gNyi;6@Fzc1lI<^2@u@Y!r-(uX0O&*Fq^jS2BGyrs{d=#dZAt_3<^S+A|m8&
+zsfSi%@`nW1$se}0LA9BgEz8=VENjb`W#W@P=5Fyx+3XiH)}S$gd;Q8bzj7$b!iuV{
+zn7fm^7@ZxXWxzNT-e1%CJD@nPg5sPF(nd%{gz$UxzLT$#WG@3YxW_h44pIlY;6O5`
+z=GCa9^PtAgsj*cb=<GO>-Un^0^WQ*2qWYN5{4jA8@W8V~7kGMe`c^~XxeWR>(1)R4
+z3%zK|Wde~wLuK-Bp#G39`|!qVy01=wI_s(iRWID){=CSI<iECUq_?{KiCt02(<C{_
+zBzLhHt5++=J#eWEa#k-MR00MAGGq5kgA>g{_3L;r&9NqD-&_(S0AhKT&|!lCfM6@^
+zfb`~J?bT<KJHR7n7i>#uMHEt&L-+`m0p(K|`ZaL#JAoE~UQ3{2gax*i!$NWm48giN
+zdodMIRRJs+2b7dArBV#kQuL#=z6p;9yfkI-obRx9No=vf4l@(?K(rFa8k`*?1Uz+3
+zS(lkf`0Ht%phBIH&Q{KGQzTI}JMs|`m!9K)CyG!Q)gkF(7u?b+?7gQ7f`z^JR6}0}
+z{qo$iHJE?R=+g#@AgqRd4fM;QuOre{C}*N}+3JKqB2{~aokGos9{Yt*^N1dMeToco
+zHvcP|e*^epp+?tZuL9+^sWU(o2{kY3u~&d{*;E<|m_iI-RvAU&Fq1k96;J9lS^*6)
+z@F8j*xS+>=iJn=d$4;YXRyKPnkl<|?p)5mwq6H|3$WmA_d9uenizw`3eAsDwvm<?O
+zn9Vb<3pLLTb9n}09v|lO%o~&`&NHtHHD`w1dFBjdit@}WXqpDNVc3-yq-O<;P;)Lb
+z4UOh@uEMLJ09y%*f+gqXwwEQ^M%R&f7vgMRpfyhfJ4ELeMaLKY7k%*C*{=Zp|HA_K
+z|IB|L|DP&A4gW*@zd#uFTX}2n|EZhB|EF#d{?9Mz%i;e8_Qi%@3*rBTY`#kP|CD}<
+z@c#`K``^O<owo%4cWQ6auX<DXzjLmjZAi@G|H7TP4*wSpQZ&8*{?Ds@G5nu5TEzd0
+z`2S|`|CvSnzli_aulvDZ5&wVYw}nOgU+|;EBL4sX!2g|#_`l%)02lGUjqB%u{oJnv
+N^F&_)|NrHke*!^mhMoWb
+
+-- 
+2.7.4
+

--- a/meta-resin-morty/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
+++ b/meta-resin-morty/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
@@ -1,0 +1,15 @@
+FILESEXTRAPATHS_append := ":${THISDIR}/files"
+
+SRC_URI_append = " \
+    file://0001-Revert-rt2870sta-Update-rt3071.bin-to-match-rt2870.b.patch \
+    file://0002-Revert-linux-firmware-update-rt2870.bin-rt2800usb-dr.patch \
+"
+
+LIC_FILES_CHKSUM_remove = " file://WHENCE;md5=f514a0c53c5d73c2fe98d5861103f0c6"
+LIC_FILES_CHKSUM_append = " file://WHENCE;md5=64134282232eb967c0d48e52048967cc"
+
+do_patch () {
+    cd ${S}
+    git apply ${WORKDIR}/0001-Revert-rt2870sta-Update-rt3071.bin-to-match-rt2870.b.patch
+    git apply ${WORKDIR}/0002-Revert-linux-firmware-update-rt2870.bin-rt2800usb-dr.patch
+}


### PR DESCRIPTION
The patch 0001-btrfs-progs-utils-make-sure-set_label_mounted-uses-c.patch
has been merged in btrfs-tools version 4.6 so now we only need to make sure
it gets applied to version older than 4.6

Signed-off-by: Florin Sarbu <florin@resin.io>

connects to https://github.com/resin-os/resinos/issues/113