### PR TITLE
kernel-resin.bbclass: Convert iterable

### DIFF
--- a/meta-resin-common/classes/kernel-resin.bbclass
+++ b/meta-resin-common/classes/kernel-resin.bbclass
@@ -414,7 +414,7 @@ python do_kernel_resin_aufs_fetch_and_unpack() {
     # does not exist in aufs-util repository, then "aufs4.9", "aufs4.8"
     # or something numerically smaller is the branch for your kernel.'
 
-    for key, value in reversed(aufsdict.items()) :
+    for key, value in reversed(list(aufsdict.items())) :
         if key.split('+')[0] is kernelversion:
             aufsbranch = key
             break


### PR DESCRIPTION
dictionary view object to a list

This fixes the following error:

*** 0417:    for key, value in reversed(aufsdict.items()) :
     0418:        if key.split('+')[0] is kernelversion:
     0419:            aufsbranch = key
     0420:            break
     0421:
Exception: TypeError: argument to reversed() must be a sequence

Signed-off-by: Florin Sarbu <florin@resin.io>