### PR TITLE
docker-utils.inc: Fix unclosed socket warnings for the 1.X branch

### DIFF
--- a/meta-resin-common/recipes-containers/docker-disk/docker-utils.inc
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-utils.inc
@@ -9,7 +9,8 @@ def connected(d):
     REMOTE_SERVER = d.getVar('RESIN_CHECK_CONN_URL', True)
     try:
         host = socket.gethostbyname(REMOTE_SERVER)
-        socket.create_connection((host, 80), 2)
+        testSocket = socket.create_connection((host, 80), 2)
+        testSocket.close()
         return "yes"
     except:
         pass


### PR DESCRIPTION
Python 3 reveals these warnings:

WARNING: docker-custom-disk.bb: <string>:12: ResourceWarning: unclosed
<socket.socket fd=28, family=AddressFamily.AF_INET, type=2049, proto=6,
laddr=('138.201.202.11', 55360), raddr=('52.207.178.113', 80)>

WARNING: docker-resin-supervisor-disk.bb: <string>:12: ResourceWarning:
unclosed <socket.socket fd=32, family=AddressFamily.AF_INET, type=2049,
proto=6, laddr=('138.201.202.11', 43862), raddr=('52.73.159.23', 80)>

Signed-off-by: Florin Sarbu <florin@resin.io>