### PR TITLE
Switch to ext4 for rootfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Switch rootfs to ext4 [Andrei]
 * Adapt resinhup for poky morty migration [Florin]
 * Add support for multiple entries in INTERNAL_DEVICE_KERNEL [Andrei]
 * Fix bug with the .docker mountpoint [Theodor]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Use static resolv.conf [Andrei]
 * Switch rootfs to ext4 [Andrei]
 * Adapt resinhup for poky morty migration [Florin]
 * Add support for multiple entries in INTERNAL_DEVICE_KERNEL [Andrei]

--- a/meta-resin-common/classes/image_types_resin.bbclass
+++ b/meta-resin-common/classes/image_types_resin.bbclass
@@ -9,7 +9,7 @@ inherit image_types
 #                               - if dst is ommited ('src:' format used), absolute path of src will be used as dst
 #
 # Optional:
-# RESIN_SDIMG_ROOTFS_TYPE       - rootfs image to be used [default: ext3]
+# RESIN_SDIMG_ROOTFS_TYPE       - rootfs image to be used [default: ext4]
 # RESIN_BOOT_SPACE              - size of boot partition in KiB [default: 40960]
 # RESIN_SDIMG_COMPRESSION       - define this to compress the final SD image with gzip, xz or bzip2 [default: empty]
 
@@ -76,8 +76,7 @@ RESIN_BOOT_SPACE ?= "40960"
 # Set alignment to 4MB [in KiB]
 IMAGE_ROOTFS_ALIGNMENT = "4096"
 
-# Use an uncompressed ext3 by default as rootfs
-RESIN_SDIMG_ROOTFS_TYPE ?= "ext3"
+RESIN_SDIMG_ROOTFS_TYPE ?= "ext4"
 
 # Default bootloader to virtual/bootloader
 RESIN_IMAGE_BOOTLOADER ?= "virtual/bootloader"

--- a/meta-resin-common/recipes-connectivity/dnsmasq/dnsmasq_%.bbappend
+++ b/meta-resin-common/recipes-connectivity/dnsmasq/dnsmasq_%.bbappend
@@ -4,7 +4,6 @@ SRC_URI_append = " \
     file://dnsmasq.conf \
     file://dnsmasq.conf.systemd \
     file://resolv.conf \
-    file://systemd-dnsmasq.conf \
     "
 
 # for dnsmasq versions older than 2.76 we need to still apply the following patch:
@@ -14,14 +13,11 @@ python() {
     if packageVersion < '2.76':
         d.setVar('SRC_URI', srcURI + ' ' + 'file://0001-Treat-REFUSED-not-SERVFAIL-as-an-unsuccessful-upstre.patch')
 }
-FILES_${PN} += "${exec_prefix}/lib/tmpfiles.d/"
 
 do_install_append() {
     if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
         install -d ${D}${sysconfdir}/systemd/system/dnsmasq.service.d
         install -c -m 0644 ${WORKDIR}/dnsmasq.conf.systemd ${D}${sysconfdir}/systemd/system/dnsmasq.service.d/dnsmasq.conf
         install -c -m 0644 ${WORKDIR}/resolv.conf ${D}${sysconfdir}
-        install -d ${D}${exec_prefix}/lib/tmpfiles.d/
-        install -c -m 0644 ${WORKDIR}/systemd-dnsmasq.conf ${D}${exec_prefix}/lib/tmpfiles.d/
     fi
 }

--- a/meta-resin-common/recipes-connectivity/dnsmasq/files/systemd-dnsmasq.conf
+++ b/meta-resin-common/recipes-connectivity/dnsmasq/files/systemd-dnsmasq.conf
@@ -1,1 +1,0 @@
-w /run/resolv.conf - - - - # we use dnsmasq at 127.0.0.2 so that user containers can run their own dns cache and forwarder and not conflict with dnsmasq on the host\nnameserver 127.0.0.2\n

--- a/meta-resin-common/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-resin-common/recipes-core/systemd/systemd_%.bbappend
@@ -36,6 +36,9 @@ do_install_append() {
 
     ln -s ${datadir}/zoneinfo ${D}${sysconfdir}/localtime
     ln -s ../proc/self/mounts ${D}${sysconfdir}/mtab
+
+    # resolv.conf is a static file containing the dnsmasq IP and deployed by dnsmasq package
+    rm -rf ${D}/${sysconfdir}/resolv.conf
 }
 
 # add pool.ntp.org as default ntp server


### PR DESCRIPTION
Fixes https://github.com/resin-os/resinos/issues/196
Connected to https://github.com/resin-os/resinos/issues/113 because now the yocto depends on ext4 for live images. 