### PR TITLE
host-update-resin.bbclass: Fix missing quoting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Fix missing quotes when testing for IMGDEPLOYDIR [Florin]
+
 # v2.0-beta.9 - 2017-02-07
 
 * Use static resolv.conf [Andrei]

--- a/meta-resin-common/classes/host-update-resin.bbclass
+++ b/meta-resin-common/classes/host-update-resin.bbclass
@@ -25,10 +25,10 @@ IMAGE_CMD_resinhup-tar () {
     mcopy -i ${WORKDIR}/boot.img -sv ::/ ${RESIN_HUP_TEMP_DIR_BOOT}
     # check if we are running on a poky version which deploys to IMGDEPLOYDIR instead of DEPLOY_DIR_IMAGE (poky morty introduced this change)
     # and create the archive accordingly
-    if [ -d ${IMGDEPLOYDIR} ]; then
+    if [ -d "${IMGDEPLOYDIR}" ]; then
         tar -xf ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.tar -C ${RESIN_HUP_TEMP_DIR}
     else
-        tar -xf ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.tar -C ${RESIN_HUP_TEMP_DIR}
+        tar -xf ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.tar -C ${RESIN_HUP_TEMP_DIR}
     fi
 
     # Quirks


### PR DESCRIPTION
and undeclared variable

If entering the if branch where IMGDEPLOYDIR is not declared
then expect IMAGE_NAME_SUFFIX is not declared either.

Signed-off-by: Florin Sarbu <florin@resin.io>