### PR TITLE
docker-resin-supervisor-disk: add armv7ve support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Configure an armv7ve repository for the Resin Supervisor [Michal]
 * Fix the location where to create the resinhup bundles when using poky morty [Florin]
 * Introduce debug tools package group add mkfs.ext4 in resin-image [Andrei]
 * Halve the UUID length to 16 bytes [Michal]

--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
@@ -4,6 +4,7 @@ require docker-disk.inc
 SUPERVISOR_REPOSITORY_armv5 = "resin/armel-supervisor"
 SUPERVISOR_REPOSITORY_armv6 = "resin/rpi-supervisor"
 SUPERVISOR_REPOSITORY_armv7a = "resin/armv7hf-supervisor"
+SUPERVISOR_REPOSITORY_armv7ve = "resin/armv7hf-supervisor"
 SUPERVISOR_REPOSITORY_aarch64 = "resin/armv7hf-supervisor"
 SUPERVISOR_REPOSITORY_x86 = "resin/i386-supervisor"
 SUPERVISOR_REPOSITORY_x86-64 = "resin/amd64-supervisor"


### PR DESCRIPTION
When switching from jethro to morty, the architecture for the rpi3
changes from "armv7a" to "armv7ve", which is armv7a + virtualization.