### PR TITLE
Add mkfs.ext4 to resin-image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Introduce debug tools package group add mkfs.ext4 in resin-image [Andrei]
 * Halve the UUID length to 16 bytes [Michal]
 
 # v2.0.0-beta11 - 2017-02-15

--- a/meta-resin-common/recipes-core/images/resin-image.bb
+++ b/meta-resin-common/recipes-core/images/resin-image.bb
@@ -32,6 +32,7 @@ IMAGE_FEATURES_append = " \
     "
 
 IMAGE_INSTALL_append = " \
+    packagegroup-resin-debugtools \
     packagegroup-resin-connectivity \
     packagegroup-resin \
     "

--- a/meta-resin-common/recipes-core/packagegroups/packagegroup-resin-debugtools.bb
+++ b/meta-resin-common/recipes-core/packagegroups/packagegroup-resin-debugtools.bb
@@ -1,0 +1,10 @@
+SUMMARY = "Resin Debug Tools Package Group"
+LICENSE = "Apache-2.0"
+
+PR = "r0"
+
+inherit packagegroup
+
+RDEPENDS_${PN} = " \
+    e2fsprogs-mke2fs \
+    "


### PR DESCRIPTION
Connects to https://github.com/resin-os/resinos/issues/174