### PR TITLE
docker-resin-supervisor-disk: Update supervisor to v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Update supervisor to v4.0.0 [Pablo]
 * Change "test -z" with "test -n" in the U-Boot MMC scanning procedure [Florin]
 * Implement MMC scanning for U-Boot [Andrei]
 * Resin-info should not be present in our production images [Theodor]

--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
@@ -9,7 +9,7 @@ SUPERVISOR_REPOSITORY_aarch64 = "resin/armv7hf-supervisor"
 SUPERVISOR_REPOSITORY_x86 = "resin/i386-supervisor"
 SUPERVISOR_REPOSITORY_x86-64 = "resin/amd64-supervisor"
 
-SUPERVISOR_TAG ?= "v3.0.1"
+SUPERVISOR_TAG ?= "v4.0.0"
 TARGET_REPOSITORY ?= "${SUPERVISOR_REPOSITORY}"
 TARGET_TAG ?= "${SUPERVISOR_TAG}"
 LED_FILE ?= "/dev/null"


### PR DESCRIPTION
Closes #589 

(Jenkins build will fail until the supervisor is built)

Signed-off-by: Pablo Carranza Velez <pablo@resin.io>