### PR TITLE
[1.X] docker-resin-supervisor-disk: Update supervisor to v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Update supervisor to v4.0.0 [Pablo]
 * Remove the supervisor container in the update script [Pablo]
 * Do not remove the supervisor container in every start [Pablo]
 * Update supervisor to v3.0.0 [Pablo]

--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
@@ -8,7 +8,7 @@ SUPERVISOR_REPOSITORY_aarch64 = "resin/armv7hf-supervisor"
 SUPERVISOR_REPOSITORY_x86 = "resin/i386-supervisor"
 SUPERVISOR_REPOSITORY_x86-64 = "resin/amd64-supervisor"
 
-SUPERVISOR_TAG ?= "v3.0.0"
+SUPERVISOR_TAG ?= "v4.0.0"
 TARGET_REPOSITORY ?= "${SUPERVISOR_REPOSITORY}"
 TARGET_TAG ?= "${SUPERVISOR_TAG}"
 LED_FILE ?= "/dev/null"


### PR DESCRIPTION
Connects to #589 
(Jenkins build will fail until the supervisor is built)

Signed-off-by: Pablo Carranza Velez <pablo@resin.io>