### PR TITLE
Ship with e2fsprogs-tune2fs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Ship with e2fsprogs-tune2fs [Michal]
+
 # v2.0.0-rc3 - 2017-03-14
 
 * Fix flasher detection in initramfs scripts [Andrei]

--- a/meta-resin-common/recipes-support/resinhup/resinhup.bb
+++ b/meta-resin-common/recipes-support/resinhup/resinhup.bb
@@ -11,12 +11,13 @@ FILES_${PN} = "${bindir}"
 
 RDEPENDS_${PN} = " \
     bash \
-    jq \
-    systemd \
-    docker \
-    coreutils \
-    resin-device-progress \
     busybox \
+    coreutils \
+    docker \
+    e2fsprogs-tune2fs \
+    jq \
+    resin-device-progress \
+    systemd \
     "
 
 do_install() {


### PR DESCRIPTION
resinhup: install e2label
    
The e2label utility is provided by the e2fsprogs-tune2fs package.
    
This utility is a prerequisite to switching the root partition for Intel
based boards (grub.cfg).
    
Also sort list.