### PR TITLE
Add support for transparent proxy redirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Add support for transparent proxy redirection using redsocks [Pablo]
 * Add prerequisites for ipk packages in resinOS images [Andrei]
 * Update supervisor to v5.0.0 [Pablo]
 * Allow downloading a missing supervisor [Will]

--- a/meta-resin-common/classes/kernel-resin.bbclass
+++ b/meta-resin-common/classes/kernel-resin.bbclass
@@ -80,6 +80,7 @@ RESIN_CONFIGS ?= " \
     governor \
     mbim \
     qmi \
+    misc \
     "
 
 #
@@ -342,6 +343,11 @@ RESIN_CONFIGS[mbim] = " \
 # support for qmi cell modems
 RESIN_CONFIGS[qmi] = " \
     CONFIG_USB_NET_QMI_WWAN=m \
+    "
+
+# various other configurations
+RESIN_CONFIGS[misc] = " \
+    CONFIG_NF_NAT_REDIRECT=m \
     "
 
 ###########

--- a/meta-resin-common/recipes-connectivity/redsocks/redsocks_0.5.bb
+++ b/meta-resin-common/recipes-connectivity/redsocks/redsocks_0.5.bb
@@ -1,0 +1,17 @@
+DESCRIPTION = "redsocks - transparent socks redirector"
+SECTION = "net/misc"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM="file://README;beginline=74;endline=78;md5=edd3a93090d9025f47a1fdec44ace593"
+
+SRCREV = "27b17889a43e32b0c1162514d00967e6967d41bb"
+
+SRC_URI = "git://github.com/darkk/redsocks.git"
+
+DEPENDS = "libevent"
+
+S = "${WORKDIR}/git"
+
+do_install () {
+    install -d ${D}${bindir}
+    install -m 0775 ${S}/redsocks ${D}${bindir}/redsocks
+}

--- a/meta-resin-common/recipes-connectivity/resin-proxy-config/resin-proxy-config.bb
+++ b/meta-resin-common/recipes-connectivity/resin-proxy-config/resin-proxy-config.bb
@@ -1,0 +1,35 @@
+DESCRIPTION = "resin proxy configuration"
+SECTION = "console/utils"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${RESIN_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = " \
+    file://redsocks.service \
+    file://resin-proxy-config \
+    file://resin-proxy-config.service \
+    "
+S = "${WORKDIR}"
+
+inherit allarch systemd useradd
+
+PACKAGES = "${PN}"
+
+SYSTEMD_SERVICE_${PN} = "resin-proxy-config.service redsocks.service"
+RDEPENDS_${PN} = "redsocks iptables"
+
+USERADD_PACKAGES = "${PN}"
+USERADD_PARAM_${PN} += "--system redsocks"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0775 ${WORKDIR}/resin-proxy-config ${D}${bindir}/resin-proxy-config
+
+    if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+        install -d ${D}${systemd_unitdir}/system
+        install -c -m 0644 ${WORKDIR}/resin-proxy-config.service ${D}${systemd_unitdir}/system
+        install -c -m 0644 ${WORKDIR}/redsocks.service ${D}${systemd_unitdir}/system
+        sed -i -e 's,@BASE_BINDIR@,${base_bindir},g' \
+            -e 's,@BINDIR@,${bindir},g' \
+            ${D}${systemd_unitdir}/system/*.service
+    fi
+}

--- a/meta-resin-common/recipes-connectivity/resin-proxy-config/resin-proxy-config/redsocks.service
+++ b/meta-resin-common/recipes-connectivity/resin-proxy-config/resin-proxy-config/redsocks.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=redsocks transparent proxy redirector
+Requires=mnt-boot.mount resin-proxy-config.service
+After=mnt-boot.mount resin-proxy-config.service dnsmasq.service
+ConditionPathExists=/mnt/boot/system-proxy/redsocks.conf
+
+[Service]
+User=redsocks
+ExecStart=@BINDIR@/redsocks -c /mnt/boot/system-proxy/redsocks.conf
+Restart=on-failure
+RestartSec=10s
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-resin-common/recipes-connectivity/resin-proxy-config/resin-proxy-config/resin-proxy-config
+++ b/meta-resin-common/recipes-connectivity/resin-proxy-config/resin-proxy-config/resin-proxy-config
@@ -1,0 +1,57 @@
+#!/bin/sh
+#
+# iptables configuration for redsocks
+#
+
+set -e
+
+. /usr/sbin/resin-vars
+
+if [ ! -f "$CONFIG_PATH" ]; then
+	echo "resin-proxy-config: $CONFIG_PATH does not exist."
+	exit 1
+else
+	echo "resin-proxy-config: Found config.json in $CONFIG_PATH ."
+fi
+
+REDSOCKSCONF=${CONFIG_PATH%/*}/system-proxy/redsocks.conf
+NOPROXYFILE=${CONFIG_PATH%/*}/system-proxy/no_proxy
+
+# Always clear the REDSOCKS chain if it exists (in case we're restarting with a changed configuration)
+iptables -t nat -D OUTPUT -p tcp -j REDSOCKS || true
+iptables -t nat -F REDSOCKS || true
+iptables -t nat -X REDSOCKS || true
+
+if [ ! -f "$REDSOCKSCONF" ]; then
+	echo "resin-proxy-config: No proxy configuration found, skipping."
+	exit 0
+fi
+
+# Redsocks needs a redsocks user to work properly with our setup
+id -u redsocks > /dev/null 2>&1 || (echo "ERROR: redsocks user doesn't exist" && exit 1)
+
+# Set up iptables chain for redsocks
+iptables -t nat -N REDSOCKS
+
+# Traffic coming from redsocks should not go back to redsocks...
+iptables -t nat -A REDSOCKS -m owner --uid-owner redsocks -j RETURN
+
+# Use every line in the no_proxy file as an IP/subnet to not redirect through redsocks
+if [ -f "$NOPROXYFILE" ]; then
+	while read -r line; do
+		if [ ! -z "$line" ]; then
+			iptables -t nat -A REDSOCKS -d "$line" -j RETURN
+		fi
+	done < "$NOPROXYFILE"
+fi
+
+iptables -t nat -A REDSOCKS -d 0.0.0.0/8 -j RETURN
+iptables -t nat -A REDSOCKS -d 10.0.0.0/8 -j RETURN
+iptables -t nat -A REDSOCKS -d 127.0.0.0/8 -j RETURN
+iptables -t nat -A REDSOCKS -d 169.254.0.0/16 -j RETURN
+iptables -t nat -A REDSOCKS -d 172.16.0.0/12 -j RETURN
+iptables -t nat -A REDSOCKS -d 192.168.0.0/16 -j RETURN
+iptables -t nat -A REDSOCKS -d 224.0.0.0/4 -j RETURN
+iptables -t nat -A REDSOCKS -d 240.0.0.0/4 -j RETURN
+iptables -t nat -A REDSOCKS -p tcp -j REDIRECT --to-ports 12345
+iptables -t nat -A OUTPUT -p tcp -j REDSOCKS

--- a/meta-resin-common/recipes-connectivity/resin-proxy-config/resin-proxy-config/resin-proxy-config.service
+++ b/meta-resin-common/recipes-connectivity/resin-proxy-config/resin-proxy-config/resin-proxy-config.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Resin proxy configuration service
+Requires=mnt-boot.mount
+After=mnt-boot.mount dnsmasq.service
+
+[Service]
+Type=oneshot
+ExecStart=@BASE_BINDIR@/sh @BINDIR@/resin-proxy-config
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-resin-common/recipes-core/packagegroups/packagegroup-resin-connectivity.bb
+++ b/meta-resin-common/recipes-core/packagegroups/packagegroup-resin-connectivity.bb
@@ -22,6 +22,7 @@ CONNECTIVITY_PACKAGES = " \
     crda \
     dnsmasq \
     openvpn \
+    resin-proxy-config \
     usb-modeswitch \
     wireless-tools \
     "

--- a/meta-resin-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-resin-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -179,6 +179,15 @@ if [ -d "$CONFIG_NM" ]; then
 else
     inform "No system connections found to transfer on the internal device."
 fi
+# Copy proxy configuration files
+CONFIG_PROXY="${CONFIG_PATH%/*}/system-proxy/"
+if [ -d "$CONFIG_PROXY" ]; then
+    inform "Transferring proxy configuration on the internal device."
+    rm -rf "$INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT/system-proxy/"
+    cp -rvf "$CONFIG_PROXY" "$INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT"
+else
+    inform "No proxy configuration found to transfer on the internal device."
+fi
 # Copy bootloader config file
 if [[ -n "${INTERNAL_DEVICE_BOOTLOADER_CONFIG}" ]] && [[ -f "${EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}/${INTERNAL_DEVICE_BOOTLOADER_CONFIG}" ]]; then
         if [[ -z "${INTERNAL_DEVICE_BOOTLOADER_CONFIG_PATH}" ]]; then


### PR DESCRIPTION
This PR adds a recipe for [redsocks](http://darkk.net.ru/redsocks/), which allows transparent redirection to SOCKS and HTTP proxies.

It introduces a `resin-proxy-config` service, which looks for redsocks.conf inside a system-proxy folder in the boot partition. The service creates the corresponding iptables rules and starts redsocks, only if the configuration file is found (otherwise it just exists).

Users wanting a device to connect behind a proxy would have to add a `redsocks.conf` file at the `/mnt/boot/system-proxy/`, specifying whatever proxy configuration they need but ensuring that:
* `daemon = off` is set, so that redsocks doesn't fork (because the service type is `simple`)
* `local_port = 12345` is set, so that the iptables rules and redsocks' port match.

(I left the port shown in redsocks examples, but we can change it if we want to use a different one).

Additionally, `resin-proxy-config` can read a `/mnt/boot/system-proxy/no_proxy` file with a newline-separated list of IPs or subnets to not route through the proxy.

This has been tested with http-connect and socks5 proxies and works as expected.