### PR TITLE
Skip docker images check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Skip the check that uses "docker images" for the supervisor image [Pablo]
 * Don't stop plymouth at boot [Andrei]
 
 # v2.0.0-rc5 - 2017-03-24

--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
@@ -72,13 +72,6 @@ python () {
     else:
         bb.warn("resin-supervisor-disk: No connectivity, skipped pulling supervisor image.")
 
-    # Inspect for fetching the version only if image exists
-    # on Fedora 23 at least, docker has suffered slight changes (https://bugzilla.redhat.com/show_bug.cgi?id=1312934)
-    # hence we need the following workaround until the above bug is fixed:
-    imagechk_cmd = "docker images | grep '^\S*%s\s*%s'" % (target_repository, tag_repository)
-    imagechk_output = subprocess.Popen(imagechk_cmd, shell=True, stdout=subprocess.PIPE).communicate()[0]
-    if imagechk_output == "":
-        bb.fatal("resin-supervisor-disk: No local supervisor images found.")
     version_cmd = "echo -n $(docker inspect %s:%s | jq --raw-output '.[0].Config.Env[] | select(startswith(\"VERSION=\")) | split(\"VERSION=\") | .[1]')" % (target_repository, tag_repository)
     version_output = subprocess.Popen(version_cmd, shell=True, stdout=subprocess.PIPE).communicate()[0]
     if sys.version_info.major >= 3 :


### PR DESCRIPTION
The supervisor recipe checked for the presence of the supervisor image by using docker images and a regex. This was unstable,
so we remove it and the check will still happen with a "docker inspect" that is done to fetch the version. If that fails we'll
get a "Cannot fetch version" error that will be in this case indicative or a missing supervisor image.