### PR TITLE
resin-provisioner: workaround upx failing to compress resin-provision…

### DIFF
--- a/meta-resin-common/recipes-go/resin-provisioner/resin-provisioner_1.0.4.bb
+++ b/meta-resin-common/recipes-go/resin-provisioner/resin-provisioner_1.0.4.bb
@@ -9,6 +9,9 @@ GO_IMPORT = "github.com/resin-os/resin-provisioner"
 
 inherit binary-compress
 FILES_COMPRESS = "${bindir}/resin-provision"
+# FIXME upx fails to compress resin-provision on Aarch64
+# upx: /usr/bin/resin-provision: UnknownExecutableFormatException
+FILES_COMPRESS_aarch64 = ""
 
 do_install_append() {
     # We currently don't use the server binary


### PR DESCRIPTION
… on Aarch64

upx fails to compress resin-provision on Aarch64:
upx: resin-provision: UnknownExecutableFormatException

$ file resin-provision
resin-provision: ELF 64-bit LSB  executable, ARM aarch64, version 1 (SYSV), statically linked, not stripped

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>