### PR TITLE
Avoid writing to /root when running nohup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Avoid writing to /root when running nohup [pvizeli]
 * Update supervisor to v4.1.2 [Pablo]
 * run-resinhup-ssh: fix typos for commandline arguments and help [Gergely]
 * Update supervisor to v4.0.0 [Pablo]

--- a/meta-resin-common/recipes-support/resinhup/resinhup/run-resinhup.sh
+++ b/meta-resin-common/recipes-support/resinhup/resinhup/run-resinhup.sh
@@ -579,7 +579,7 @@ if [ $RESINHUP_EXIT -eq 0 ] || [ $RESINHUP_EXIT -eq 2 ] || [ $RESINHUP_EXIT -eq 
     # Everything is fine - Reboot
     if [ "$NOREBOOT" == "no" ]; then
         log "Rebooting board in 5 seconds..."
-        nohup bash -c " /bin/sleep 5 ; /sbin/reboot " &
+        nohup bash -c " /bin/sleep 5 ; /sbin/reboot " > /dev/null 2>&1 &
     else
         log "'No-reboot' requested."
     fi


### PR DESCRIPTION

This PR cherry picks the changes from:

https://github.com/resin-os/meta-resin/pull/614

This allows us to build with Jenkins and adds a changelog.