### PR TITLE
prepare-openvpn: Switch to watching for config.json changes in order to update the VPN config

### DIFF
--- a/meta-resin-common/recipes-connectivity/openvpn/openvpn/prepare-openvpn
+++ b/meta-resin-common/recipes-connectivity/openvpn/openvpn/prepare-openvpn
@@ -7,24 +7,14 @@ set -e
 _vpn_port=443
 readonly _vpn_port
 
-if [ ! -f "$CONFIG_PATH" ]; then
-	echo "prepare-openvpn: $CONFIG_PATH - No such file."
+# If the user api key exists we use it instead of the deviceApiKey as it means we haven't done the key exchange yet
+_device_api_key=${PROVISIONING_API_KEY:-DEVICE_API_KEY}
+
+if [ "$UUID" = "null" ] || [ "$_device_api_key" = "null" ]; then
+	echo "prepare-openvpn: UUID and/or APIKEY missing from config file, VPN cannot connect"
 	exit 1
 fi
 
-while :; do
-	_uuid=$(jq -r '.uuid' "$CONFIG_PATH")
-	# If the user api key exists we use it instead of the deviceApiKey as it means we haven't done the key exchange yet
-	_device_api_key=$(jq -r '.apiKey // .deviceApiKey' "$CONFIG_PATH")
-
-	if [ "$_uuid" = "null" ] || [ "$_device_api_key" = "null" ]; then
-		echo "prepare-openvpn: UUID and/or APIKEY missing from config file, VPN cannot connect"
-		sleep 2
-	else
-		echo "$_uuid" > /var/volatile/vpnfile
-		echo "$_device_api_key" >> /var/volatile/vpnfile
-		break
-	fi
-done
-
+echo $UUID > /var/volatile/vpnfile
+echo $_device_api_key >> /var/volatile/vpnfile
 sed -e "/remote .*/ c\remote $VPN_ENDPOINT $_vpn_port" /etc/openvpn/resin.conf > /run/openvpn/resin.conf

--- a/meta-resin-common/recipes-connectivity/openvpn/openvpn/prepare-openvpn.service
+++ b/meta-resin-common/recipes-connectivity/openvpn/openvpn/prepare-openvpn.service
@@ -9,4 +9,4 @@ RemainAfterExit=yes
 ExecStart=@BINDIR@/prepare-openvpn
 
 [Install]
-WantedBy=resin.target
+WantedBy=config-json.service

--- a/meta-resin-common/recipes-support/resin-vars/resin-vars.bb
+++ b/meta-resin-common/recipes-support/resin-vars/resin-vars.bb
@@ -2,10 +2,14 @@ DESCRIPTION = "Resin Configuration Recipe"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${RESIN_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
-SRC_URI = "file://resin-vars"
+SRC_URI = " \
+    file://resin-vars \
+    file://config-json.path \
+    file://config-json.service \
+    "
 S = "${WORKDIR}"
 
-inherit allarch
+inherit allarch systemd
 
 FILES_${PN} = "${sbindir}"
 
@@ -16,7 +20,19 @@ do_configure[noexec] = "1"
 do_compile[noexec] = "1"
 do_build[noexec] = "1"
 
+SYSTEMD_SERVICE_${PN} = "config-json.path config-json.service"
+
 do_install() {
     install -d ${D}${sbindir}
     install -m 0755 ${WORKDIR}/resin-vars ${D}${sbindir}/
+
+    if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+        install -d ${D}${systemd_unitdir}/system
+        install -c -m 0644 ${WORKDIR}/config-json.path ${D}${systemd_unitdir}/system
+        install -c -m 0644 ${WORKDIR}/config-json.service ${D}${systemd_unitdir}/system
+        sed -i -e 's,@BASE_BINDIR@,${base_bindir},g' \
+            -e 's,@SBINDIR@,${sbindir},g' \
+            -e 's,@BINDIR@,${bindir},g' \
+            ${D}${systemd_unitdir}/system/*.service
+    fi
 }

--- a/meta-resin-common/recipes-support/resin-vars/resin-vars/config-json.path
+++ b/meta-resin-common/recipes-support/resin-vars/resin-vars/config-json.path
@@ -1,0 +1,10 @@
+[Unit]
+Description=Config.json path watch
+Requires=mnt-boot.mount
+After=mnt-boot.mount
+
+[Path]
+PathChanged=/mnt/boot/config.json
+
+[Install]
+WantedBy=mnt-boot.mount

--- a/meta-resin-common/recipes-support/resin-vars/resin-vars/config-json.service
+++ b/meta-resin-common/recipes-support/resin-vars/resin-vars/config-json.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Config.json watcher
+Requires=mnt-boot.mount
+After=mnt-boot.mount
+
+[Service]
+Type=oneshot
+ExecStart=/bin/echo 'config.json changed'
+
+[Install]
+WantedBy=mnt-boot.mount


### PR DESCRIPTION
This PR is related to the key switching from #656, and allows us to use a dedicated provisioning key in order to register and get the device api key for #656.  Without this PR it is necessary to use a user-api-key as otherwise the prepare-vpn service will try to use the provisioning key (which will fail), and it will not switch to using the device key (which will work) until the device is rebooted, this PR will make the VPN switch to using the correct key as soon as it is available

<img src="https://frontapp.com/assets/img/icons/favicon-32x32.png" height="16" width="16" alt="Front logo" /> [Front conversations](https://app.frontapp.com/open/top_1xql)