### PR TITLE
Include e2fsprogs utilities for resinhup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Add e2fsprogs utilities for resinhup [Will]
+
 # v1.26 - 2017-04-25
 
 * Avoid writing to /root when running nohup [pvizeli]

--- a/meta-resin-common/recipes-support/resinhup/resinhup.bb
+++ b/meta-resin-common/recipes-support/resinhup/resinhup.bb
@@ -18,6 +18,9 @@ RDEPENDS_${PN} = " \
     resin-device-progress \
     busybox \
     util-linux-blkid \
+    e2fsprogs-mke2fs \
+    e2fsprogs-resize2fs \
+    e2fsprogs-tune2fs \
     "
 
 do_install() {


### PR DESCRIPTION

In order to update to resinOS 2.x we need to be able to manipulate ext2/3/4 filesystems.