### PR TITLE
resin-supervisor.service: Add systemd timesync service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Change log
 -----------
-
+* Set start of resin-supervisor in dependence to timesync [Pascal]
 * Disable all password logins on production images, rather than just root logins - this gets rid of the password prompt dialog that users have seen. [Page]
 
 # v2.0.4 - 2017-05-16

--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/resin-supervisor.service
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/resin-supervisor.service
@@ -9,6 +9,7 @@ Requires=\
     etc-resin\x2dsupervisor.mount
 After=\
     docker.service \
+    systemd-timesyncd.service \
     resin\x2ddata.mount \
     resin-device-uuid.service \
     resin-device-api-key.service \


### PR DESCRIPTION
Some time it start resin-supervisor before the time sync have start. With that change, systemd aware that the supervisor will start after that.