### PR TITLE
Add ability to run generated resinhup images also as Docker containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Add Dockerfile template and entry.sh for running the generated tar as a Docker container [Praneeth]
+
 # v2.0.7 - 2017-06-28
 
 * Add support for transparent proxy redirection using redsocks [Pablo]

--- a/meta-resin-common/recipes-core/packagegroups/packagegroup-resin.bb
+++ b/meta-resin-common/recipes-core/packagegroups/packagegroup-resin.bb
@@ -21,6 +21,7 @@ RDEPENDS_${PN} += " \
     resin-hostname \
     resin-state-reset \
     resinhup \
+    resin-dockerdevice \
     aufs-util \
     ${@bb.utils.contains('RESIN_CONNECTABLE', '1', 'resin-connectable', '', d)} \
     ${@bb.utils.contains('RESIN_CONNECTABLE', '1', 'resin-provisioner', '', d)} \

--- a/meta-resin-common/recipes-support/resin-dockerdevice/resin-dockerdevice.bb
+++ b/meta-resin-common/recipes-support/resin-dockerdevice/resin-dockerdevice.bb
@@ -1,0 +1,23 @@
+DESCRIPTION = "Resin custom Docker entry file"
+SECTION = "console/utils"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${RESIN_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+PR = "r1"
+
+SRC_URI = " \
+    file://entry.sh \
+    file://Dockerfile.template \
+    "
+S = "${WORKDIR}"
+
+
+RDEPENDS_${PN} = " \
+    bash \
+    "
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/entry.sh ${D}${bindir}
+    install -m 0755 ${WORKDIR}/Dockerfile.template ${DEPLOY_DIR_IMAGE}
+}

--- a/meta-resin-common/recipes-support/resin-dockerdevice/resin-dockerdevice/Dockerfile.template
+++ b/meta-resin-common/recipes-support/resin-dockerdevice/resin-dockerdevice/Dockerfile.template
@@ -1,0 +1,10 @@
+FROM #{VERSION}
+
+VOLUME /mnt/state
+VOLUME /mnt/data
+VOLUME /mnt/data/docker
+VOLUME /mnt/boot
+VOLUME /var/lib/docker
+
+STOPSIGNAL 37
+CMD ["/usr/bin/entry.sh"]

--- a/meta-resin-common/recipes-support/resin-dockerdevice/resin-dockerdevice/entry.sh
+++ b/meta-resin-common/recipes-support/resin-dockerdevice/resin-dockerdevice/entry.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -m
+
+function mount_dev()
+{
+	mkdir -p /tmp
+	mount -t devtmpfs none /tmp
+	mkdir -p /tmp/shm
+	mount --move /dev/shm /tmp/shm
+	mkdir -p /tmp/mqueue
+	mount --move /dev/mqueue /tmp/mqueue
+	mkdir -p /tmp/pts
+	mount --move /dev/pts /tmp/pts
+	touch /tmp/console
+	mount --move /dev/console /tmp/console
+	umount /dev || true
+	mount --move /tmp /dev
+
+	# Since the devpts is mounted with -o newinstance by Docker, we need to make
+	# /dev/ptmx point to its ptmx.
+	# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
+	ln -sf /dev/pts/ptmx /dev/ptmx
+	mount -t debugfs nodev /sys/kernel/debug
+
+}
+
+function init_systemd()
+{
+	env > /etc/docker.env
+
+	# Mask the services that cannot be run inside a docker container
+	systemctl mask \
+		dev-hugepages.mount \
+		sys-fs-fuse-connections.mount \
+		sys-kernel-config.mount \
+		display-manager.service \
+		getty@.service \
+		systemd-logind.service \
+		systemd-remount-fs.service \
+		getty.target \
+		graphical.target \
+		systemd-ask-password-plymouth.service \
+		plymouth-start.service \
+		plymouth-reboot.service \
+		plymouth-halt.service \
+		plymouth-poweroff.service \
+		plymouth-quit.service
+
+	# Remove data/state/boot mounts as they are not mounted in the docker container.
+	# Also remove the mount points as dependencies of any services.
+	cd /lib/systemd/system && \
+		find . -type f -exec  sed -i 's|mnt-state.mount ||g' {} \;  && \
+		find . -type f -exec  sed -i 's|mnt-data.mount ||g' {} \;  && \
+		find . -type f -exec  sed -i 's|mnt-boot.mount ||g' {} \;  && \
+		find . -type f -exec  sed -i 's|mnt-state.mount||g' {} \;  && \
+		find . -type f -exec  sed -i 's|mnt-data.mount||g' {} \;  && \
+		find . -type f -exec  sed -i 's|mnt-boot.mount||g' {} \;  && \
+		rm /lib/systemd/system/mnt-data.mount && \
+		rm /lib/systemd/system/mnt-state.mount && \
+		rm /lib/systemd/system/mnt-boot.mount
+
+	# This is required to allow the container to run when the dockerd is started with
+	# user namespace remapping ( --userns-remap )
+	addgroup -S dockremap && \
+		adduser -S -G dockremap dockremap && \
+		echo 'dockremap:165536:65536' >> /etc/subuid && \
+		echo 'dockremap:165536:65536' >> /etc/subgid
+
+	exec /sbin/init quiet systemd.show_status=0
+}
+
+mount_dev
+
+init_systemd


### PR DESCRIPTION
This PR adds a Dockerfile.template and entry.sh for running the generated tar as a Docker container.

This is consumed by jenkins_build.sh in resin-yocto-scripts https://github.com/resin-os/resin-yocto-scripts/pull/72

Command to run the container - Assuming the OS version.

```
docker run -d --privileged -v config.json:/mnt/boot/config.json resin/resinos:2.0.4_rev1-qemux86-64
```