### PR TITLE
networkmanager: set reconnection attempts to infinity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Set NetworkManager connection attempts to infinity [petrosagg]
 * Update Docker to 17.03.1 [Theodor]
 * Include fsck.vfat in resinOS [Andrei]
 

--- a/meta-resin-common/recipes-connectivity/networkmanager/files/NetworkManager.conf
+++ b/meta-resin-common/recipes-connectivity/networkmanager/files/NetworkManager.conf
@@ -1,6 +1,7 @@
 [main]
 dns=default
 plugins=keyfile
+autoconnect-retries-default=0
 
 [keyfile]
 unmanaged-devices=type:bridge;type:tun;type:veth


### PR DESCRIPTION
NetworkManager will attempt to connect to a network 4 times by default before bailing out. This is unsuitable for resin device that can be deployed in flaky networks.

Setting `autoconnect-retries-default` to 0 will cause NM to never stop trying to connect.

https://developer.gnome.org/NetworkManager/unstable/nm-settings.html#nm-settings.property.connection.autoconnect-retries