### PR TITLE
resinhup: apply BeagleBone memory fixes for affected resinOS releases before update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Add BeagleBone memory hack to script to resinhup [Gergely]
 * Add busybox patch to fix tar unpacking [Will]
 * Get correct current version in resinhup script [Andrei]
 * Remove resinhup script name heuristics to use with proxy [Gergely]

--- a/meta-resin-common/recipes-support/resinhup/resinhup/run-resinhup.sh
+++ b/meta-resin-common/recipes-support/resinhup/resinhup/run-resinhup.sh
@@ -196,6 +196,20 @@ function runPreHacks {
         sed --in-place "s|curl --silent --header \"User-Agent:\" --compressed|wget -qO-|" $script_path
         sed --in-place "s|curl -s --compressed|wget -qO-|" $script_path
     fi
+
+    # Earlier BeagleBone releases might fail to update due to memory pressure.
+    # The fix for this was released in v1.24.0, for versions below that apply
+    # changes manually
+    if [ "$SLUG" == "beaglebone-black" ] ||
+       [ "$SLUG" == "beaglebone-green" ] ||
+       [ "$SLUG" == "beaglebone-green-wifi" ]; then
+           if version_gt $CURRENT_HOSTOS_VERSION "1.24.0" || [ "$CURRENT_HOSTOS_VERSION" == "1.24.0" ]; then
+               log "BeagleBone memory hack: no changes required."
+           else
+               log "BeagleBone memory hack: applying memory settings."
+               sysctl -w vm.min_free_kbytes="8192" vm.dirty_ratio="5" vm.dirty_background_ratio="10"
+           fi
+    fi
 }
 
 function runPostHacks {


### PR DESCRIPTION
Basically automatic application of https://github.com/resin-os/resin-beaglebone/blob/1.X/layers/meta-resin-beaglebone/recipes-core/fix-mmc-bbb/files/fix-mmc-bbb.conf