### PR TITLE
resinhup: new flag to set supervisor to the target release's default version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Add flag to automatically supervisor after resinhup [Gergely]
 * Add BeagleBone memory hack to script to resinhup [Gergely]
 * Add busybox patch to fix tar unpacking [Will]
 * Get correct current version in resinhup script [Andrei]

--- a/scripts/resinhup/run-resinhup-ssh.sh
+++ b/scripts/resinhup/run-resinhup-ssh.sh
@@ -62,6 +62,9 @@ Options:
   --only-supervisor
         Update only the supervisor.
 
+  --supervisor-release-update
+        Run run-resinhup.sh with --supervisor-release-update . See run-resinhup.sh help for more details.
+
   --no-reboot
         Run run-resinhup.sh with --no-reboot . See run-resinhup.sh help for more details.
 
@@ -265,6 +268,9 @@ while [[ $# > 0 ]]; do
             SUPERVISOR_TAG=$2
             RESINHUP_ARGS="$RESINHUP_ARGS --supervisor-tag $SUPERVISOR_TAG"
             shift
+            ;;
+        --supervisor-release-update)
+            RESINHUP_ARGS="$RESINHUP_ARGS --supervisor-release-update"
             ;;
         --resinhup-tag)
             if [ -z "$2" ]; then


### PR DESCRIPTION
Check the target resinOS release's default supervisor version, if the current
version is older, then tag the device for the new version in the API so that
it's updated after reboot, if the update is successful.