### PR TITLE
Add a quirk for mtab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Add a quirk for /etc/mtab [Will]
 * Switch to resin.io ntp pool [petrosagg]
 * Undefine backwards compatibilty variable, INITRAMFS_TASK [Theodor]
 * Enable CONFIG_KEYS, docker 17 requirment [Theodor]

--- a/meta-resin-common/classes/image-resin.bbclass
+++ b/meta-resin-common/classes/image-resin.bbclass
@@ -191,6 +191,7 @@ QUIRK_FILES ?= " \
     etc/hostname \
     etc/hosts \
     etc/resolv.conf \
+    etc/mtab \
     "
 resin_root_quirks () {
     # Quirks
@@ -199,11 +200,11 @@ resin_root_quirks () {
     # Make sure you run this before packing
     if [ "${QUIRK_FILES}" != "" ];then
         for file in ${QUIRK_FILES}; do
-            src=${IMAGE_ROOTFS}/$file
-            dst=${IMAGE_ROOTFS}/quirks/$file
-            if [ -f $src ]; then
-                mkdir -p $(dirname $dst)
-                cp $src $dst
+            src="${IMAGE_ROOTFS}/$file"
+            dst="${IMAGE_ROOTFS}/quirks/$file"
+            if [ -f "$src" ] || [ -L "$src" ]; then
+                mkdir -p $(dirname "$dst")
+                cp -d "$src" "$dst"
             else
                 bbfatal "Quirks: $src doesn't exist."
             fi


### PR DESCRIPTION
By default docker creates a symlink for /etc/mtab that is slightly different to what systemd is expecting, causing systemd to try and rewrite the symlink on boot. This causes resinhup-ed 2.x images to error on boot due to a read-only root filesystem.