### PR TITLE
Use specified version of supervisor when starting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Allow downloading a missing supervisor [Will]
 * Add busybox patch to fix tar unpacking [Will]
 * Include support for the RT5572 wireless chipset [Theodor]
 * Add a quirk for /etc/mtab [Will]

--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/start-resin-supervisor
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/start-resin-supervisor
@@ -1,8 +1,8 @@
-#!/bin/sh -e
+#!/bin/sh
 
 source /usr/sbin/resin-vars
 
-SUPERVISOR_IMAGE_ID=$(docker inspect --format='{{.Id}}' $SUPERVISOR_IMAGE)
+SUPERVISOR_IMAGE_ID=$(docker inspect --format='{{.Id}}' $SUPERVISOR_IMAGE:$SUPERVISOR_TAG)
 SUPERVISOR_CONTAINER_IMAGE_ID=$(docker inspect --format='{{.Image}}' resin_supervisor || echo "")
 
 runSupervisor() {
@@ -28,7 +28,7 @@ runSupervisor() {
         -e LED_FILE=${LED_FILE} \
         -e LISTEN_PORT=$LISTEN_PORT \
         -e SUPERVISOR_IMAGE=${SUPERVISOR_IMAGE} \
-        ${SUPERVISOR_IMAGE}
+        ${SUPERVISOR_IMAGE}:${SUPERVISOR_TAG}
 }
 
 ([ "$SUPERVISOR_IMAGE_ID" == "$SUPERVISOR_CONTAINER_IMAGE_ID" ] && docker start --attach resin_supervisor) || runSupervisor

--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/update-resin-supervisor
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/update-resin-supervisor
@@ -149,8 +149,5 @@ echo "SUPERVISOR_IMAGE=$image_name:$tag" > $UPDATECONF
 echo "Start supervisor..."
 systemctl start resin-supervisor
 
-# Mark supervisor as working. This version will run when the device reboots.
-echo "Mark pulled tag as latest..."
-$DOCKER tag -f "$image_name:$tag" "$image_name:latest"
 sed --in-place "s|SUPERVISOR_IMAGE=.*|SUPERVISOR_IMAGE=$image_name|" /etc/resin-supervisor/supervisor.conf
 sed --in-place "s|SUPERVISOR_TAG=.*|SUPERVISOR_TAG=$tag|" /etc/resin-supervisor/supervisor.conf

--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/update-resin-supervisor
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/update-resin-supervisor
@@ -149,5 +149,4 @@ echo "SUPERVISOR_IMAGE=$image_name:$tag" > $UPDATECONF
 echo "Start supervisor..."
 systemctl start resin-supervisor
 
-sed --in-place "s|SUPERVISOR_IMAGE=.*|SUPERVISOR_IMAGE=$image_name|" /etc/resin-supervisor/supervisor.conf
-sed --in-place "s|SUPERVISOR_TAG=.*|SUPERVISOR_TAG=$tag|" /etc/resin-supervisor/supervisor.conf
+sed -i -e "s|SUPERVISOR_IMAGE=.*|SUPERVISOR_IMAGE=$image_name|" -e "s|SUPERVISOR_TAG=.*|SUPERVISOR_TAG=$tag|" /etc/resin-supervisor/supervisor.conf


### PR DESCRIPTION

This change is an attempt to implement Andrei's suggestion for simplifying 1.x to 2.x upgrades. When we upgrade to 2.x the docker containers are wiped out (we switched from btrfs to aufs) so there is no supervisor available to run. Using the tag specified in the supervisor.conf directly allows us to fall back to downloading the container.