### PR TITLE
Add dosfstools for FAT fsck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Include fsck.vfat in resinOS [Will]
 * Update supervisor to v4.3.1 [Pablo]
 * Add BeagleBone memory hack to script to resinhup [Gergely]
 * Add busybox patch to fix tar unpacking [Will]

--- a/meta-resin-common/recipes-core/packagegroups/packagegroup-resin.bb
+++ b/meta-resin-common/recipes-core/packagegroups/packagegroup-resin.bb
@@ -18,6 +18,7 @@ RDEPENDS_${PN} += " \
     resin-btrfs-expand \
     resin-logs \
     resin-extend-expand \
+    dosfstools \
     resin-info \
     resinhup \
     ${@bb.utils.contains('RESIN_CONNECTABLE', '1', 'resin-connectable', '', d)} \


### PR DESCRIPTION
Add dosfstools for fsck.vfat which allows repairing some corrupt FAT filesystems. This is a backport of the change already on master to 1.X.