### PR TITLE
versionist: Make it work with current format

### DIFF
--- a/versionist.conf.js
+++ b/versionist.conf.js
@@ -49,7 +49,7 @@ module.exports = {
   // Always add the entry to the top of the Changelog, below the header.
   addEntryToChangelog: {
     preset: 'prepend',
-    fromLine: 6
+    fromLine: 2
   },
 
   // Only include a commit when there is a footer tag of 'change-type'.
@@ -78,7 +78,7 @@ module.exports = {
   },
 
   template: [
-    '## v{{version}} - {{moment date "Y-MM-DD"}}',
+    '# v{{version}} - {{moment date "Y-MM-DD"}}',
     '',
     '{{#each commits}}',
     '{{#if this.author}}',


### PR DESCRIPTION
Currently we only use two lines for the file header and we use heading, not
sub-deading, for version lines.

Change-type: patch
Changelog-entry: Use current changelog format with versionist
Signed-off-by: Andrei Gherzan <andrei@resin.io>