### PR TITLE
kernel-resin.bbclass: Add config needed for our usage of redsocks

### DIFF
--- a/meta-resin-common/classes/kernel-resin.bbclass
+++ b/meta-resin-common/classes/kernel-resin.bbclass
@@ -81,6 +81,7 @@ RESIN_CONFIGS ?= " \
     mbim \
     qmi \
     misc \
+    redsocks \
     "
 
 #
@@ -348,6 +349,11 @@ RESIN_CONFIGS[qmi] = " \
 # various other configurations
 RESIN_CONFIGS[misc] = " \
     CONFIG_NF_NAT_REDIRECT=m \
+    "
+
+# configs needed for our usage of redsocks
+RESIN_CONFIGS[redsocks] = " \
+    CONFIG_NETFILTER_XT_MATCH_OWNER=m \
     "
 
 ###########


### PR DESCRIPTION
We use iptables to append a new rule to a REDSOCKS chain by creating
a rule specification using the "-m" (match) parameter. As such, we need
iptables owner match support enabled in all our kernels.

Change-type: patch
Changelog-entry: Add iptables owner match support for all kernels
Signed-off-by: Florin Sarbu <florin@resin.io>