### PR TITLE
resin-init-flasher: Fix splash image migration

### DIFF
--- a/meta-resin-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-resin-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -167,7 +167,8 @@ if ! mount /dev/disk/by-label/resin-boot $INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT; 
         fail "Failed to mount disk labeled as 'resin-boot'."
 fi
 # Copy custom splash dir
-cp -r $EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT/$SPLASH_DIRNAME $INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT/$SPLASH_DIRNAME
+mkdir -p "$INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT/$SPLASH_DIRNAME"
+cp -r $EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT/$SPLASH_DIRNAME/* $INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT/$SPLASH_DIRNAME
 # Copy json configuration file from external (flasher) to the internal (booting) device
 cp -rvf "$CONFIG_PATH" "$INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT"
 # Copy Network Manager connection files


### PR DESCRIPTION
When migrating the splash directory don't copy the directoy but the content of
it. As well make sure the destination directory is created.

Change-type: patch
Changelog-entry: Fix splash image migration in flasher images
Signed-off-by: Andrei Gherzan <andrei@resin.io>