### PR TITLE
Add support for customizing NTP server list

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,3 +174,7 @@ Boolean. Enable or disable persistent logging on this device.
 
 String. The country in which the device is operating. This is used for setting with WiFi regulatory domain.
 
+### ntpServers
+
+String. A space-separated list of NTP servers to use for time synchronization. Defaults to resinio.pool.ntp.org servers.
+

--- a/meta-resin-common/recipes-connectivity/resin-ntp-config/resin-ntp-config.bb
+++ b/meta-resin-common/recipes-connectivity/resin-ntp-config/resin-ntp-config.bb
@@ -1,0 +1,25 @@
+DESCRIPTION = "resin NTP configuration"
+SECTION = "console/utils"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${RESIN_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = " \
+    file://resin-ntp-config \
+    file://resin-ntp-config.service \
+    "
+
+S = "${WORKDIR}"
+
+inherit allarch systemd
+
+SYSTEMD_SERVICE_${PN} = "resin-ntp-config.service"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0775 ${WORKDIR}/resin-ntp-config ${D}${bindir}/resin-ntp-config
+
+    install -d ${D}${systemd_unitdir}/system
+    install -c -m 0644 ${WORKDIR}/resin-ntp-config.service ${D}${systemd_unitdir}/system
+    sed -i -e 's,@BASE_BINDIR@,${base_bindir},g' \
+      -e 's,@BINDIR@,${bindir},g' ${D}${systemd_unitdir}/system/resin-ntp-config.service
+}

--- a/meta-resin-common/recipes-connectivity/resin-ntp-config/resin-ntp-config/resin-ntp-config
+++ b/meta-resin-common/recipes-connectivity/resin-ntp-config/resin-ntp-config/resin-ntp-config
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# copy over NTP configuration
+#
+
+set -e
+
+. /usr/sbin/resin-vars
+
+if [ ! -f "$CONFIG_PATH" ]; then
+	echo "resin-ntp-config: $CONFIG_PATH does not exist."
+	exit 1
+else
+	echo "resin-ntp-config: Found config.json in $CONFIG_PATH ."
+fi
+
+if [ ! -z "$NTP_SERVERS" ]; then
+	cat >/etc/systemd/timesyncd.conf <<EOF
+[Time]
+NTP=$NTP_SERVERS
+EOF
+fi
+
+exit 0

--- a/meta-resin-common/recipes-connectivity/resin-ntp-config/resin-ntp-config/resin-ntp-config.service
+++ b/meta-resin-common/recipes-connectivity/resin-ntp-config/resin-ntp-config/resin-ntp-config.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Resin NTP configuration service
+DefaultDependencies=no
+Requires=mnt-boot.mount etc-systemd-timesyncd.conf.mount
+After=mnt-boot.mount etc-systemd-timesyncd.conf.mount
+Before=systemd-timesyncd.service
+
+[Service]
+ExecStart=@BASE_BINDIR@/sh @BINDIR@/resin-ntp-config
+Type=oneshot
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-resin-common/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-resin-common/recipes-core/systemd/systemd_%.bbappend
@@ -60,6 +60,8 @@ do_install_append() {
     rm ${D}/lib/systemd/system/sysinit.target.wants/systemd-journal-flush.service
 }
 
+RDEPENDS_${PN}_append = " resin-ntp-config"
+
 # add pool.ntp.org as default ntp server
 PACKAGECONFIG[ntp] = "--with-ntp-servers='0.resinio.pool.ntp.org 1.resinio.pool.ntp.org 2.resinio.pool.ntp.org 3.resinio.pool.ntp.org',,,"
 

--- a/meta-resin-common/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-resin-common/recipes-core/systemd/systemd_%.bbappend
@@ -61,7 +61,7 @@ do_install_append() {
 }
 
 # add pool.ntp.org as default ntp server
-PACKAGECONFIG[ntp] = "--with-ntp-servers=0.resinio.pool.ntp.org 1.resinio.pool.ntp.org 2.resinio.pool.ntp.org 3.resinio.pool.ntp.org,,,"
+PACKAGECONFIG[ntp] = "--with-ntp-servers='0.resinio.pool.ntp.org 1.resinio.pool.ntp.org 2.resinio.pool.ntp.org 3.resinio.pool.ntp.org',,,"
 
 PACKAGECONFIG_append = " ntp"
 

--- a/meta-resin-common/recipes-support/resin-mounts/resin-mounts.bb
+++ b/meta-resin-common/recipes-support/resin-mounts/resin-mounts.bb
@@ -9,6 +9,7 @@ SRC_URI = " \
     file://etc-docker.mount \
     file://etc-dropbear.mount \
     file://etc-systemd-system-resin.target.wants.mount \
+    file://etc-systemd-timesyncd.conf.mount \
     file://etc-hostname.mount \
     file://etc-resinx2dsupervisor.mount \
     file://etc-NetworkManager-systemx2dconnections.mount \
@@ -32,6 +33,7 @@ SYSTEMD_SERVICE_${PN} = " \
     etc-docker.mount \
     etc-dropbear.mount \
     etc-systemd-system-resin.target.wants.mount \
+    etc-systemd-timesyncd.conf.mount \
     etc-hostname.mount \
     var-lib-systemd.mount \
     var-log-journal.mount \
@@ -60,7 +62,6 @@ do_install () {
     install -d ${D}${sysconfdir}/systemd/system/resin-bind.target.wants
     install -c -m 0644 ${WORKDIR}/resin-bind.target ${D}${systemd_unitdir}/system/
 
-
     if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
         install -d ${D}${systemd_unitdir}/system
         install -c -m 0644 \
@@ -71,6 +72,7 @@ do_install () {
             ${WORKDIR}/etc-dropbear.mount \
             ${WORKDIR}/etc-hostname.mount \
             ${WORKDIR}/etc-systemd-system-resin.target.wants.mount \
+            ${WORKDIR}/etc-systemd-timesyncd.conf.mount \
             ${WORKDIR}/var-lib-systemd.mount \
             ${WORKDIR}/var-log-journal.mount \
             ${WORKDIR}/home-root-.rnd.mount \

--- a/meta-resin-common/recipes-support/resin-mounts/resin-mounts/etc-systemd-timesyncd.conf.mount
+++ b/meta-resin-common/recipes-support/resin-mounts/resin-mounts/etc-systemd-timesyncd.conf.mount
@@ -1,0 +1,14 @@
+[Unit]
+Description=systemd-timesyncd configuration bind mount
+DefaultDependencies=no
+Requires=mnt-state.mount resin-state-reset.service
+After=mnt-state.mount resin-state-reset.service
+
+[Mount]
+What=/mnt/state/root-overlay/etc/systemd/timesyncd.conf
+Where=/etc/systemd/timesyncd.conf
+Type=none
+Options=bind
+
+[Install]
+WantedBy=resin-bind.target

--- a/meta-resin-common/recipes-support/resin-vars/resin-vars/resin-vars
+++ b/meta-resin-common/recipes-support/resin-vars/resin-vars/resin-vars
@@ -64,6 +64,7 @@ if [ -f $CONFIG_PATH ]; then
     APPLICATION_ID=$(jq --raw-output '.applicationId // empty' $CONFIG_PATH)
     DEVICE_TYPE=$(jq --raw-output '.deviceType // empty' $CONFIG_PATH)
     REGISTERED_AT=$(jq --raw-output '.registered_at // empty' $CONFIG_PATH)
+    NTP_SERVERS=$(jq --raw-output '.ntpServers // empty' $CONFIG_PATH)
     if [ -z "$API_ENDPOINT" -o -z "$LISTEN_PORT" -o -z "$MIXPANEL_TOKEN" -o -z "$PUBNUB_PUBLISH_KEY" -o -z "$PUBNUB_SUBSCRIBE_KEY" -o -z "$REGISTRY_ENDPOINT" -o -z "$VPN_ENDPOINT" ]; then
         echo "[WARNING] $0 : Couldn't read some variables from $CONFIG_PATH"
     fi


### PR DESCRIPTION

Read a list of NTP servers from config.json if available and configure systemd-timesyncd to use them, otherwise use the defaults. This uses a new service rather than resin-net-config due to boot time ordering issues.
