### PR TITLE
resin-sanity.bbclass: Require systemd

### DIFF
--- a/meta-resin-common/classes/resin-sanity.bbclass
+++ b/meta-resin-common/classes/resin-sanity.bbclass
@@ -22,3 +22,5 @@ python resinos_sanity_handler() {
 
 addhandler resinos_sanity_handler
 resinos_sanity_handler[eventmask] = "bb.event.BuildStarted"
+
+REQUIRED_DISTRO_FEATURES += " systemd"


### PR DESCRIPTION
Add systemd as a required distro feature.

Change-type: patch
Signed-off-by: Will Newton <willn@resin.io>