### PR TITLE
docker-disk: Don't set latest tag

### DIFF
--- a/meta-resin-common/recipes-containers/docker-disk/files/entry.sh
+++ b/meta-resin-common/recipes-containers/docker-disk/files/entry.sh
@@ -39,7 +39,6 @@ done
 
 if [ -n "${TARGET_REPOSITORY}" ] && [ -n "${TARGET_TAG}" ]; then
     docker pull $TARGET_REPOSITORY:$TARGET_TAG
-    docker tag $TARGET_REPOSITORY:$TARGET_TAG $TARGET_REPOSITORY:latest
 fi
 
 kill -TERM $(cat /var/run/docker.pid) && wait $(cat /var/run/docker.pid) && umount /resin-data


### PR DESCRIPTION
We use a specific tag when starting supervisor and latest tag was a relic from
an old implementation. Right now it's not needed anymore.

Change-type: patch
Changelog-entry: Remove latest supervisor tag as it is not used anymore
Signed-off-by: Andrei Gherzan <andrei@resin.io>