### PR TITLE
resin-state-reset: Make sure data is on disk before marking it done

### DIFF
--- a/meta-resin-common/recipes-support/resin-state-reset/resin-state-reset/resin-state-reset
+++ b/meta-resin-common/recipes-support/resin-state-reset/resin-state-reset/resin-state-reset
@@ -42,3 +42,9 @@ done
 
 # Clean after ourselves
 rm -rf ${RESIN_STATE_MP}/rollback
+
+# Make sure everything is on disk otherwise the flag 'remove_me_to_reset'
+# might end up before other data on state partition. If so, in the case of a
+# power loss we might end up in a state with inconsistent data (eg.
+# supervisor.conf is empty).
+sync


### PR DESCRIPTION
We mark that the state partition was initialized using a file called
remove_me_to_reset . If this file ends up on the disk but some data written by
the state doesn't, next boot will get corrupted.

Example. The reset creates supervisor.conf file in state partition and other
files and then writes remove_me_to_reset. Immediately afterwards the board
loses power. At next boot we can end up in a state where remove_me_to_reset
ended up on disk while the supervisor.conf didn't which will break the board.

Change-type: patch
Changelog-entry: Make sure resin-state-reset doesn't end up in an inconsistent state
Signed-off-by: Andrei Gherzan <andrei@resin.io>

Fixes https://github.com/resin-os/meta-resin/issues/676