### PR TITLE
Add support for configuring DNS servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,6 @@ String. The country in which the device is operating. This is used for setting w
 
 String. A space-separated list of NTP servers to use for time synchronization. Defaults to resinio.pool.ntp.org servers.
 
+### dnsServers
+
+String. A space-separated list of preferred DNS servers to use for name resolution. Falls back to DHCP provided servers and Google DNS.

--- a/meta-resin-common/recipes-connectivity/dnsmasq/files/dnsmasq.conf.systemd
+++ b/meta-resin-common/recipes-connectivity/dnsmasq/files/dnsmasq.conf.systemd
@@ -5,4 +5,4 @@ After=resin-net-config.service
 [Service]
 OOMScoreAdjust=-1000
 ExecStart=
-ExecStart=/usr/bin/dnsmasq -x /run/dnsmasq.pid -a 127.0.0.2 -7 /etc/dnsmasq.d/ -r /etc/resolv.dnsmasq -z
+ExecStart=/usr/bin/dnsmasq -x /run/dnsmasq.pid -a 127.0.0.2 -7 /etc/dnsmasq.d/ -r /etc/resolv.dnsmasq -z --servers-file=/run/dnsmasq.servers

--- a/meta-resin-common/recipes-connectivity/resin-net-config/resin-net-config/resin-net-config
+++ b/meta-resin-common/recipes-connectivity/resin-net-config/resin-net-config/resin-net-config
@@ -24,4 +24,11 @@ if [ ! -z "$COUNTRY" ]; then
 	iw reg set "$COUNTRY"
 fi
 
+# add additional DNS servers to dnsmasq configuration
+DNS_SERVER_FILE=/run/dnsmasq.servers
+echo > $DNS_SERVER_FILE
+for dns in $DNS_SERVERS; do
+	echo "server=$dns" >> $DNS_SERVER_FILE
+done
+
 exit 0

--- a/meta-resin-common/recipes-support/resin-vars/resin-vars/resin-vars
+++ b/meta-resin-common/recipes-support/resin-vars/resin-vars/resin-vars
@@ -65,6 +65,7 @@ if [ -f $CONFIG_PATH ]; then
     DEVICE_TYPE=$(jq --raw-output '.deviceType // empty' $CONFIG_PATH)
     REGISTERED_AT=$(jq --raw-output '.registered_at // empty' $CONFIG_PATH)
     NTP_SERVERS=$(jq --raw-output '.ntpServers // empty' $CONFIG_PATH)
+    DNS_SERVERS=$(jq --raw-output '.dnsServers // empty' $CONFIG_PATH)
     if [ -z "$API_ENDPOINT" -o -z "$LISTEN_PORT" -o -z "$MIXPANEL_TOKEN" -o -z "$PUBNUB_PUBLISH_KEY" -o -z "$PUBNUB_SUBSCRIBE_KEY" -o -z "$REGISTRY_ENDPOINT" -o -z "$VPN_ENDPOINT" ]; then
         echo "[WARNING] $0 : Couldn't read some variables from $CONFIG_PATH"
     fi


### PR DESCRIPTION

Add support for a new config.json key "dnsServers" that contains a space separated list of DNS servers to use in preference to the DHCP-provided and defaults.