### PR TITLE
resin-filesystem-expand: Remove set -e

### DIFF
--- a/meta-resin-common/recipes-support/resin-expand/resin-filesystem-expand/resin-filesystem-expand
+++ b/meta-resin-common/recipes-support/resin-expand/resin-filesystem-expand/resin-filesystem-expand
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 DATA_PARTITION=/dev/disk/by-label/resin-data
 
 echo -n "Expand ext4 filesystem on $DATA_PARTITION... "


### PR DESCRIPTION
This script is very simple and set -e can misinterpret some of the
informative error codes from e2fsck as fatal errors. Remove set -e
as it doesn't buy us any reliability in this simple script.

Signed-off-by: Will Newton <willn@resin.io>