### PR TITLE
socat: Remove bbappend

### DIFF
--- a/meta-resin-common/recipes-connectivity/socat/socat_%.bbappend
+++ b/meta-resin-common/recipes-connectivity/socat/socat_%.bbappend
@@ -1,2 +1,0 @@
-# Fix strange license
-LICENSE = "GPL-2.0-with-OpenSSL-exception"


### PR DESCRIPTION
We no longer include socat in our base images so this is no
longer needed.

Signed-off-by: Will Newton <willn@resin.io>