### PR TITLE
resinhup: new flag to set supervisor to the target release's default version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Resinhup: add flag to update the supervisor to the one released with the target OS version [Gergely]
 * Fix connman unprotected_wifi_tether.patch splitout [Florin]
 * Update supervisor to v6.1.2 [Pablo]
 

--- a/scripts/resinhup/run-resinhup-ssh.sh
+++ b/scripts/resinhup/run-resinhup-ssh.sh
@@ -59,6 +59,9 @@ Options:
         Run run-resinhup.sh with this --supervisor-tag argument. See run-resinhup.sh
         help for more details.
 
+  --supervisor-release-update
+        Run run-resinhup.sh with --supervisor-release-update . See run-resinhup.sh help for more details.
+
   --only-supervisor
         Update only the supervisor.
 
@@ -265,6 +268,9 @@ while [[ $# -gt 0 ]]; do
             SUPERVISOR_TAG=$2
             RESINHUP_ARGS="$RESINHUP_ARGS --supervisor-tag $SUPERVISOR_TAG"
             shift
+            ;;
+        --supervisor-release-update)
+            RESINHUP_ARGS="$RESINHUP_ARGS --supervisor-release-update"
             ;;
         --resinhup-tag)
             if [ -z "$2" ]; then


### PR DESCRIPTION
With a new flag, one can tell the resinhup script to fetch the target update's supervisor version, and if it's newer than the current one running on the device, update it alongside the resinOS update.

This will enable self-service resinHUP to also do supervisor updates non-interactively.

(Updated version of #711)