### PR TITLE
dhcp_%.bbappend: Add forward space needed when doing SRC_URI_append

### DIFF
--- a/meta-resin-common/recipes-connectivity/dhcp/dhcp_%.bbappend
+++ b/meta-resin-common/recipes-connectivity/dhcp/dhcp_%.bbappend
@@ -1,3 +1,3 @@
 FILESEXTRAPATHS_append := ":${THISDIR}/files"
 
-SRC_URI_append = "file://dhclient.conf"
+SRC_URI_append = " file://dhclient.conf"


### PR DESCRIPTION
Signed-off-by: Florin Sarbu <florin@resin.io>