### PR TITLE
resinhup: bump default resinhup container to v1.2.1 (Alpine)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Resinhip: bump default resinhup container to v1.2.1 (Alpine Linux) [Gergely]
 * Resinhup: add flag to update the supervisor to the one released with the target OS version [Gergely]
 * Fix connman unprotected_wifi_tether.patch splitout [Florin]
 * Update supervisor to v6.1.2 [Pablo]

--- a/meta-resin-common/recipes-support/resinhup/resinhup/run-resinhup.sh
+++ b/meta-resin-common/recipes-support/resinhup/resinhup/run-resinhup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Default values
-TAG=v1.1.3
+TAG=v1.2.1
 FORCE=no
 ALLOW_DOWNGRADES=no
 STAGING=no


### PR DESCRIPTION
will add Changelog and thus finish PR when #761 is merged as that is more important to include.