### PR TITLE
resin-vars: Remove warning print for unset variables

### DIFF
--- a/meta-resin-common/recipes-support/resin-vars/resin-vars/resin-vars
+++ b/meta-resin-common/recipes-support/resin-vars/resin-vars/resin-vars
@@ -68,9 +68,6 @@ if [ -f $CONFIG_PATH ]; then
          NTP_SERVERS=\(.ntpServers // "")
          DNS_SERVERS=\(.dnsServers // "")
          "' $CONFIG_PATH)"
-    if [ -z "$API_ENDPOINT" -o -z "$LISTEN_PORT" -o -z "$MIXPANEL_TOKEN" -o -z "$PUBNUB_PUBLISH_KEY" -o -z "$PUBNUB_SUBSCRIBE_KEY" -o -z "$REGISTRY_ENDPOINT" -o -z "$VPN_ENDPOINT" ]; then
-        echo "[WARNING] $0 : Couldn't read some variables from $CONFIG_PATH"
-    fi
     if [ -z "$PERSISTENT_LOGGING" ]; then
         PERSISTENT_LOGGING=false
     fi


### PR DESCRIPTION
It's quite common to have unset variables and it seems like it
would be better to warn in the places where the variables are
needed rather than here.

Signed-off-by: Will Newton <willn@resin.io>