### PR TITLE
util-linux_%.bbappend: Conditionally package lsblk into a separate pa…

### DIFF
--- a/meta-resin-common/recipes-core/util-linux/util-linux_%.bbappend
+++ b/meta-resin-common/recipes-core/util-linux/util-linux_%.bbappend
@@ -4,9 +4,19 @@ python() {
 	from distutils.version import StrictVersion
 	packageVersion = d.getVar('PV', True)
 	srcURI = d.getVar('SRC_URI', True)
+	packages = d.getVar('PACKAGES', True)
 	if StrictVersion(packageVersion) >= StrictVersion('2.28'):
 		d.setVar('SRC_URI', srcURI + ' ' + 'file://0001-libblkid-don-t-check-for-size-on-UBI-char-dev.patch')
-}
 
-PACKAGES =+ "util-linux-lsblk"
-FILES_util-linux-lsblk = "${bindir}/lsblk"
+	if StrictVersion(packageVersion) < StrictVersion('2.29.1'):
+		d.setVar('FILES_util-linux-lsblk', '${bindir}/lsblk')
+
+		# we only add to PACKAGES when it contains actual values
+		# this is done because when building the resin image target, bitbake would typically run this code here multiple times and one
+		# of this runs will result in an empty PACKAGES variable to which we add "util-linux-lsblk" after which bitbake will complain:
+		#       NOTE: Resolving any missing task queue dependencies
+		#       NOTE: multiple providers are available for runtime util-linux-lsblk (util-linux, util-linux-native)
+		#       NOTE: consider defining aaa PREFERRED_RPROVIDER entry to match util-linux-lsblk
+		if packages:
+			d.setVar('PACKAGES', 'util-linux-lsblk' + ' ' + packages)
+}


### PR DESCRIPTION
…ckage

Starting with yocto pyro which contains util-linux version 2.29.1, we no longer need
to explicitly package lsblk into a separate package as that is already handled by yocto.

Signed-off-by: Florin Sarbu <florin@resin.io>