### PR TITLE
image-resin.bbclass: Set deviceType in config.json

### DIFF
--- a/meta-resin-common/classes/image-resin.bbclass
+++ b/meta-resin-common/classes/image-resin.bbclass
@@ -45,6 +45,14 @@ init_config_json() {
    # Default no to persistent-logging
    echo $(cat ${1}/config.json | jq ".persistentLogging=false") > ${1}/config.json
 
+   # Find board json and extract slug
+   common_path=$(echo "${BBLAYERS}" | grep -o -E '[^ ]+meta-resin-common')
+   json_path=${common_path}/../../../${MACHINE}.json
+   slug=$(jq .slug $json_path)
+
+   # Set deviceType for supervisor
+   echo $(cat ${1}/config.json | jq ".deviceType=$slug") > ${1}/config.json
+
    if ${@bb.utils.contains('DISTRO_FEATURES','development-image','true','false',d)}; then
        echo $(cat ${1}/config.json | jq ".hostname=\"resin\"") > ${1}/config.json
    fi


### PR DESCRIPTION
Set deviceType in config.json so unmanaged images don't have
an unknown/empty type.

Change-type: minor
Changelog-entry: Set deviceType in config.json
Signed-off-by: Will Newton <willn@resin.io>