### PR TITLE
resin-sanity.bbclass: Move systemd check to image recipes

### DIFF
--- a/meta-resin-common/classes/resin-sanity.bbclass
+++ b/meta-resin-common/classes/resin-sanity.bbclass
@@ -25,5 +25,3 @@ python resinos_sanity_handler() {
 
 addhandler resinos_sanity_handler
 resinos_sanity_handler[eventmask] = "bb.event.BuildStarted"
-
-REQUIRED_DISTRO_FEATURES += " systemd"

--- a/meta-resin-common/recipes-core/images/resin-image-flasher.bb
+++ b/meta-resin-common/recipes-core/images/resin-image-flasher.bb
@@ -2,7 +2,9 @@ SUMMARY = "Resin image flasher"
 IMAGE_LINGUAS = " "
 LICENSE = "Apache-2.0"
 
-inherit core-image image-resin
+inherit core-image image-resin distro_features_check
+
+REQUIRED_DISTRO_FEATURES += " systemd"
 
 RESIN_FLAG_FILE = "${RESIN_FLASHER_FLAG_FILE}"
 

--- a/meta-resin-common/recipes-core/images/resin-image.bb
+++ b/meta-resin-common/recipes-core/images/resin-image.bb
@@ -2,7 +2,9 @@ SUMMARY = "Resin image"
 IMAGE_LINGUAS = " "
 LICENSE = "Apache-2.0"
 
-inherit core-image image-resin
+inherit core-image image-resin distro_features_check
+
+REQUIRED_DISTRO_FEATURES += " systemd"
 
 RESIN_FLAG_FILE = "${RESIN_IMAGE_FLAG_FILE}"
 


### PR DESCRIPTION
With Yocto Pyro having this check in resin-sanity.bbclass was
causing problems, so move it.

@floion could you check if that fixes the issue for you? Thanks