### PR TITLE
resinhup: query the partition number looser for root partition.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Resinhup: fix update failure on Intel NUC due to partition matching [Gergely]
 * Update supervisor to v6.2.5 [Pablo]
 
 # v1.30 - 2017-08-16
@@ -9,7 +10,7 @@ Change log
 * Do not deploy systemd's resolv.conf file but rather use the one we add through dnsmasq [Florin]
 * Conditionally use IMGDEPLOYDIR over DEPLOY_DIR_IMAGE [Florin]
 * Plymouth: change splash image scaling to full screen instead of half [Gergely]
-* Resinhip: bump default resinhup container to v1.2.1 (Alpine Linux) [Gergely]
+* Resinhup: bump default resinhup container to v1.2.1 (Alpine Linux) [Gergely]
 * Resinhup: add flag to update the supervisor to the one released with the target OS version [Gergely]
 * Fix connman unprotected_wifi_tether.patch splitout [Florin]
 * Update supervisor to v6.1.2 [Pablo]

--- a/meta-resin-common/recipes-support/resinhup/resinhup/run-resinhup.sh
+++ b/meta-resin-common/recipes-support/resinhup/resinhup/run-resinhup.sh
@@ -393,10 +393,10 @@ function updateSupervisorConf() {
         local _new_root_number
         _current_root_device=$(findmnt -n --raw --evaluate --output=source /)
         case $_current_root_device in
-            *p2)
+            *2)
                 _new_root_number=3
                 ;;
-            *p3)
+            *3)
                 _new_root_number=2
                 ;;
             *)


### PR DESCRIPTION
The previous version matched e.g. the Raspberry Pi's `/dev/mmcblk0p2` root partition, but it fails on e.g. some Intel NUC's `/dev/sda2` partition name. Adjust the matching that both are found correctly.

Related: https://github.com/resin-os/resinhup/issues/82 (sorry, first I though it's an issue in the Python part, hence filed it there)