### PR TITLE
resin-provisioner: Re-enable UPX on AArch64

### DIFF
--- a/meta-resin-common/recipes-go/resin-provisioner/resin-provisioner_1.0.4.bb
+++ b/meta-resin-common/recipes-go/resin-provisioner/resin-provisioner_1.0.4.bb
@@ -9,9 +9,6 @@ GO_IMPORT = "github.com/resin-os/resin-provisioner"
 
 inherit binary-compress
 FILES_COMPRESS = "${bindir}/resin-provision"
-# FIXME upx fails to compress resin-provision on Aarch64
-# upx: /usr/bin/resin-provision: UnknownExecutableFormatException
-FILES_COMPRESS_aarch64 = ""
 
 do_install_append() {
     # We currently don't use the server binary


### PR DESCRIPTION
After updating UPX to 3.94 AArch64 is supported so we can re-enable
compression of executables.

Change-type: minor
Changelog-entry: Re-enable UPX compression on AArch64
Signed-off-by: Will Newton <willn@resin.io>