### PR TITLE
Don't run OpenVPN as root

### DIFF
--- a/meta-resin-common/recipes-connectivity/openvpn/openvpn/resin.conf
+++ b/meta-resin-common/recipes-connectivity/openvpn/openvpn/resin.conf
@@ -20,3 +20,5 @@ nobind
 persist-key
 persist-tun
 verb 3
+user openvpn
+group openvpn

--- a/meta-resin-common/recipes-connectivity/openvpn/openvpn_%.bbappend
+++ b/meta-resin-common/recipes-connectivity/openvpn/openvpn_%.bbappend
@@ -9,6 +9,11 @@ RESIN_CONNECTABLE_SRCURI = " \
     file://upscript.sh \
     file://downscript.sh \
     "
+
+inherit useradd
+USERADD_PACKAGES = "${PN}"
+USERADD_PARAM_${PN} += "--system -d / -M --shell /bin/nologin openvpn"
+
 SRC_URI_append = " ${@bb.utils.contains("RESIN_CONNECTABLE","1","${RESIN_CONNECTABLE_SRCURI}","",d)}"
 
 RDEPENDS_${PN} += "${@bb.utils.contains("RESIN_CONNECTABLE","1","bash jq resin-unique-key sed","",d)}"


### PR DESCRIPTION
OpenVPN should not run as root user, drop privileges to special openvpn user.

Change-Type: patch
Connects-To: #798
Changelog-entry: openvpn: Run OpenVPN service as openvpn user
Signed-off-by: Andreas Fitzek <andreas@resin.io>
---- Autogenerated Waffleboard Connection: Connects to #798