### PR TITLE
docker: set bridge subnet to 10.114.101.1/24

### DIFF
--- a/meta-resin-common/recipes-containers/docker/docker/docker.conf.systemd
+++ b/meta-resin-common/recipes-containers/docker/docker/docker.conf.systemd
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=/usr/bin/dockerd --log-driver=journald -s @DOCKER_STORAGE@ -H fd:// -H tcp://0.0.0.0:2375 --dns 172.17.0.1
+ExecStart=/usr/bin/dockerd --log-driver=journald -s @DOCKER_STORAGE@ -H fd:// -H tcp://0.0.0.0:2375 --dns 10.114.101.1 --bip 10.114.101.1/24 --fixed-cidr=10.114.101.0/25

--- a/meta-resin-common/recipes-containers/docker/docker/docker.service
+++ b/meta-resin-common/recipes-containers/docker/docker/docker.service
@@ -9,10 +9,10 @@ Before=dnsmasq.service
 [Service]
 Type=notify
 Restart=always
-ExecStart=/usr/bin/dockerd --log-driver=journald -s @DOCKER_STORAGE@ -H fd:// --dns 172.17.0.1
+ExecStart=/usr/bin/dockerd --log-driver=journald -s @DOCKER_STORAGE@ -H fd:// --dns 10.114.101.1 --bip 10.114.101.1/24 --fixed-cidr=10.114.101.0/25
 ExecStartPost=/sbin/sysctl -w net.ipv4.conf.docker0.route_localnet=1
-ExecStartPost=/usr/sbin/iptables -t nat -I DOCKER -p udp --dport 53 -j DNAT --dst 172.17.0.1/32 --to 127.0.0.2:53
-ExecStartPost=/usr/sbin/iptables -t nat -I DOCKER -p tcp --dport 53 -j DNAT --dst 172.17.0.1/32 --to 127.0.0.2:53
+ExecStartPost=/usr/sbin/iptables -t nat -I DOCKER -p udp --dport 53 -j DNAT --dst 10.114.101.1/32 --to 127.0.0.2:53
+ExecStartPost=/usr/sbin/iptables -t nat -I DOCKER -p tcp --dport 53 -j DNAT --dst 10.114.101.1/32 --to 127.0.0.2:53
 #Adjust OOMscore to -900 to make killing docker unlikely
 OOMScoreAdjust=-900
 MountFlags=slave


### PR DESCRIPTION
We change the default subnet of docker to avoid conflicts with the local
network which will cause one of the two conflicting networks to become
unroutable. Docker attempts to find an unused subnet on startup but this is not
enough to avoid coflicts in the case of resin because the network might not
have come up when docker starts (e.g slow wifi/DHCP) or might change after it
has come up (e.g resin wifi connect). Furthermore, even if the subnet
automatically selected by docker is not directly accessible from the host, it
might be through the default gateway. So no matter what we do there is a
possibility to shadow a useful subnet.

This change attempts to minimise the chances of this happening by reducing the
size of the subnet to /24 instead of /16 and also moving it to a fairly
uncommon network, 10.114.101.0. This will solve most of the networking issues
we see today. However, it should become configurable in the future.

On top of that, we split the subnet between the host and application docker
daemon. The application docker daemon allocates containers in the lower
10.114.101.0/25 subnet and the host container allocates containers in the upper
10.114.101.128/25 subnet.

This cherry-pick contains only the application docker part of this
commit but the comments above explain the reason the netmask values were
chosen.

Change-type: minor
Changelog-entry: Set docker bridge subnet to 10.114.101.1/24
Signed-off-by: Petros Angelatos <petrosagg@gmail.com>