### PR TITLE
packagegroup-resin: Make systemd-analyze dev only

### DIFF
--- a/meta-resin-common/recipes-core/packagegroups/packagegroup-resin.inc
+++ b/meta-resin-common/recipes-core/packagegroups/packagegroup-resin.inc
@@ -6,7 +6,7 @@ PR = "r1"
 inherit packagegroup
 
 RDEPENDS_${PN} = " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd-analyze', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', bb.utils.contains('DISTRO_FEATURES', 'development-image', 'systemd-analyze', '', d), '', d)} \
     ${RESIN_INIT_PACKAGE} \
     ${RESIN_MOUNTS} \
     ${RESIN_REGISTER} \


### PR DESCRIPTION
Only install systemd-analyze if we are building a development
image.

Change-type: minor
Changelog-entry: Only install systemd-analyze in development images
Signed-off-by: Will Newton <willn@resin.io>