### PR TITLE
openvpn: Fix prepare-openvpn script

### DIFF
--- a/meta-resin-common/recipes-connectivity/openvpn/openvpn/prepare-openvpn
+++ b/meta-resin-common/recipes-connectivity/openvpn/openvpn/prepare-openvpn
@@ -8,7 +8,7 @@ _vpn_port=443
 readonly _vpn_port
 
 # If the user api key exists we use it instead of the deviceApiKey as it means we haven't done the key exchange yet
-_device_api_key=${PROVISIONING_API_KEY:-DEVICE_API_KEY}
+_device_api_key=${PROVISIONING_API_KEY:-$DEVICE_API_KEY}
 
 if [ "$UUID" = "null" ] || [ "$_device_api_key" = "null" ]; then
 	echo "prepare-openvpn: UUID and/or APIKEY missing from config file, VPN cannot connect"


### PR DESCRIPTION
Use correct variable referencing in default parameter substitution

Change-type: patch
Changelog-entry: Fix variable referencing in default variable substitution inside prepare-openvpn script
Signed-off-by: Florin Sarbu <florin@resin.io>