### PR TITLE
Avoid removing the supervisor container when the supervisor exits

### DIFF
--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/start-resin-supervisor
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/start-resin-supervisor
@@ -31,4 +31,8 @@ runSupervisor() {
         ${SUPERVISOR_IMAGE}:${SUPERVISOR_TAG}
 }
 
-([ "$SUPERVISOR_IMAGE_ID" == "$SUPERVISOR_CONTAINER_IMAGE_ID" ] && docker start --attach resin_supervisor) || runSupervisor
+if [ "$SUPERVISOR_IMAGE_ID" = "$SUPERVISOR_CONTAINER_IMAGE_ID" ]; then
+    docker start --attach resin_supervisor
+else
+    runSupervisor
+fi


### PR DESCRIPTION
In the previous implementation, if docker start exited with non-zero (for instance, when
stopping the supervisor service), the right hand side of the `||` expression would start
running, removing the supervisor container, which is something we want to avoid and is unnecessary.

Changelog-entry: Avoid removing the supervisor container when the supervisor exits
Change-Type: patch
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>