### PR TITLE
mtools: Add patch to fix mtools directory creation

### DIFF
--- a/meta-resin-common/recipes-devtools/mtools/mtools/initialize-direntry.patch
+++ b/meta-resin-common/recipes-devtools/mtools/mtools/initialize-direntry.patch
@@ -1,0 +1,19 @@
+
+Ensure all fields of the direntry structure are initialized. This avoids
+potentially creating directory entries with invalid flags set.
+
+https://lists.gnu.org/archive/html/info-mtools/2014-08/msg00000.html
+
+Signed-off-by: Ronny Nilsson
+Upstream-Status: Submitted
+diff -rup mtools-4.0.18.orig/direntry.c mtools-4.0.18/direntry.c
+--- mtools-4.0.18.orig/direntry.c	2010-10-11 21:18:53.000000000 +0000
++++ mtools-4.0.18/direntry.c	2014-08-27 16:44:32.984959149 +0000
+@@ -24,6 +24,7 @@
+ 
+ void initializeDirentry(direntry_t *entry, Stream_t *Dir)
+ {
++	memset(entry, 0, sizeof(direntry_t));
+ 	entry->entry = -1;
+ /*	entry->parent = getDirentry(Dir);*/
+ 	entry->Dir = Dir;

--- a/meta-resin-common/recipes-devtools/mtools/mtools_4.0.18.bbappend
+++ b/meta-resin-common/recipes-devtools/mtools/mtools_4.0.18.bbappend
@@ -1,0 +1,4 @@
+
+FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
+SRC_URI_append = " file://initialize-direntry.patch"
+


### PR DESCRIPTION
mtools uninitialized data when creating directories which can
potentially cause filesystem corruption.

https://lists.gnu.org/archive/html/info-mtools/2014-08/msg00000.html

Change-type: minor
Changelog-entry: Patch mtools directory creation
Signed-off-by: Will Newton <willn@resin.io>