### PR TITLE
Fix host tool dependency issues for Pyro

### DIFF
--- a/meta-resin-common/recipes-connectivity/usb-modeswitch/usb-modeswitch_2.2.5.bb
+++ b/meta-resin-common/recipes-connectivity/usb-modeswitch/usb-modeswitch_2.2.5.bb
@@ -17,6 +17,8 @@ SRC_URI = " \
 SRC_URI[md5sum] = "ef86a19f0b3c4f64896d78a2ffb748e9"
 SRC_URI[sha256sum] = "8b2340303732aabc8c8e1cdd7d4352f61dcb942839f58ce22ba0ecfa122426d5"
 
+inherit pkgconfig
+
 FILES_${PN} = "${bindir} ${sysconfdir} ${nonarch_base_libdir}/udev/usb_modeswitch ${sbindir} ${localstatedir}/lib/usb_modeswitch"
 RRECOMMENDS_${PN} = "usb-modeswitch-data"
 

--- a/meta-resin-common/recipes-core/images/resin-image.bb
+++ b/meta-resin-common/recipes-core/images/resin-image.bb
@@ -45,6 +45,8 @@ generate_hostos_version () {
     echo "${HOSTOS_VERSION}" > ${DEPLOY_DIR_IMAGE}/VERSION_HOSTOS
 }
 
+DEPENDS += "jq-native"
+
 IMAGE_PREPROCESS_COMMAND += " generate_rootfs_fingerprints ; "
 IMAGE_POSTPROCESS_COMMAND += " generate_hostos_version ; "
 

--- a/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
+++ b/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
@@ -7,7 +7,10 @@ SECTION = "devel/kernel"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
-DEPENDS = "virtual/kernel"
+DEPENDS = " \
+    virtual/kernel \
+    bc-native \
+    "
 
 SRC_URI = "git://github.com/resin-os/module-headers.git;protocol=https"
 

--- a/meta-resin-jethro/recipes-devtools/jq/jq/Support-without-oniguruma.patch
+++ b/meta-resin-jethro/recipes-devtools/jq/jq/Support-without-oniguruma.patch
@@ -1,0 +1,68 @@
+From 18b4b18b41f5ed396d73449ce8d6ec408d95d6b2 Mon Sep 17 00:00:00 2001
+From: David Tolnay <dtolnay@gmail.com>
+Date: Sat, 21 Nov 2015 10:05:37 -0800
+Subject: [PATCH] Support --without-oniguruma
+
+Upstream-Status: Backport
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+
+---
+ configure.ac | 41 ++++++++++++++++++++---------------------
+ 1 file changed, 20 insertions(+), 21 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 9e2c8cf..7f6be34 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -52,27 +52,26 @@ fi
+ AC_ARG_WITH([oniguruma],
+     [AS_HELP_STRING([--with-oniguruma=prefix],
+         [try this for a non-standard install prefix of the oniguruma library])],
+-    [ONIGURUMAPATHSET=1],
+-    [ONIGURUMAPATHSET=0])
+-
+-if test $ONIGURUMAPATHSET = 1; then
+-  CFLAGS="$CFLAGS -I${with_oniguruma}/include"
+-  LDFLAGS="$LDFLAGS -L${with_oniguruma}/lib"
+-fi
+-
+-# check for ONIGURUMA library
+-HAVE_ONIGURUMA=0
+-AC_CHECK_HEADER("oniguruma.h",
+-    AC_CHECK_LIB([onig],[onig_version],[LIBS="$LIBS -lonig"; HAVE_ONIGURUMA=1;]))
+-
+-# handle check results
+-if test $HAVE_ONIGURUMA != 1; then
+-    AC_MSG_NOTICE([Oniguruma was not found.])
+-    AC_MSG_NOTICE([ Try setting the location using '--with-oniguruma=PREFIX' ])
+-else
+-    AC_DEFINE([HAVE_ONIGURUMA],1,[Define to 1 if Oniguruma is installed])
+-fi
+-
++    [],
++    [with_oniguruma=yes])
++
++AS_IF([test "x$with_oniguruma" != xno], [
++    AS_IF([test "x$with_oniguruma" != xyes], [
++        CFLAGS="$CFLAGS -I${with_oniguruma}/include"
++        LDFLAGS="$LDFLAGS -L${with_oniguruma}/lib"
++    ])
++    # check for ONIGURUMA library
++    have_oniguruma=0
++    AC_CHECK_HEADER("oniguruma.h",
++        AC_CHECK_LIB([onig],[onig_version],[LIBS="$LIBS -lonig"; have_oniguruma=1;]))
++    # handle check results
++    AS_IF([test $have_oniguruma = 1], [
++        AC_DEFINE([HAVE_ONIGURUMA], 1, [Define to 1 if Oniguruma is installed])
++    ], [
++        AC_MSG_NOTICE([Oniguruma was not found.])
++        AC_MSG_NOTICE([Try setting the location using '--with-oniguruma=PREFIX'])
++    ])
++])
+ 
+ dnl Check for valgrind
+ AC_CHECK_PROGS(valgrind_cmd, valgrind)
+-- 
+1.9.1
+

--- a/meta-resin-jethro/recipes-devtools/jq/jq_1.5.bb
+++ b/meta-resin-jethro/recipes-devtools/jq/jq_1.5.bb
@@ -1,0 +1,28 @@
+SUMMARY = "Lightweight and flexible command-line JSON processor"
+DESCRIPTION = "jq is like sed for JSON data, you can use it to slice and \
+               filter and map and transform structured data with the same \
+               ease that sed, awk, grep and friends let you play with text."
+HOMEPAGE = "https://stedolan.github.io/jq/"
+BUGTRACKER = "https://github.com/stedolan/jq/issues"
+SECTION = "utils"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://COPYING;md5=29dd0c35d7e391bb8d515eacf7592e00"
+
+SRC_URI = "https://github.com/stedolan/${BPN}/releases/download/${BP}/${BP}.tar.gz \
+           file://Support-without-oniguruma.patch \
+"
+
+SRC_URI[md5sum] = "0933532b086bd8b6a41c1b162b1731f9"
+SRC_URI[sha256sum] = "c4d2bfec6436341113419debf479d833692cc5cdab7eb0326b5a4d4fbe9f493c"
+
+inherit autotools
+
+PACKAGECONFIG[docs] = "--enable-docs,--disable-docs,ruby-native"
+PACKAGECONFIG[maintainer-mode] = "--enable-maintainer-mode,--disable-maintainer-mode,flex-native bison-native"
+PACKAGECONFIG[oniguruma] = "--with-oniguruma,--without-oniguruma,onig"
+
+OE_EXTRACONF += " \
+    --disable-valgrind \
+"
+
+BBCLASSEXTEND = "native"

--- a/meta-resin-krogoth/recipes-devtools/jq/jq/Support-without-oniguruma.patch
+++ b/meta-resin-krogoth/recipes-devtools/jq/jq/Support-without-oniguruma.patch
@@ -1,0 +1,68 @@
+From 18b4b18b41f5ed396d73449ce8d6ec408d95d6b2 Mon Sep 17 00:00:00 2001
+From: David Tolnay <dtolnay@gmail.com>
+Date: Sat, 21 Nov 2015 10:05:37 -0800
+Subject: [PATCH] Support --without-oniguruma
+
+Upstream-Status: Backport
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+
+---
+ configure.ac | 41 ++++++++++++++++++++---------------------
+ 1 file changed, 20 insertions(+), 21 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 9e2c8cf..7f6be34 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -52,27 +52,26 @@ fi
+ AC_ARG_WITH([oniguruma],
+     [AS_HELP_STRING([--with-oniguruma=prefix],
+         [try this for a non-standard install prefix of the oniguruma library])],
+-    [ONIGURUMAPATHSET=1],
+-    [ONIGURUMAPATHSET=0])
+-
+-if test $ONIGURUMAPATHSET = 1; then
+-  CFLAGS="$CFLAGS -I${with_oniguruma}/include"
+-  LDFLAGS="$LDFLAGS -L${with_oniguruma}/lib"
+-fi
+-
+-# check for ONIGURUMA library
+-HAVE_ONIGURUMA=0
+-AC_CHECK_HEADER("oniguruma.h",
+-    AC_CHECK_LIB([onig],[onig_version],[LIBS="$LIBS -lonig"; HAVE_ONIGURUMA=1;]))
+-
+-# handle check results
+-if test $HAVE_ONIGURUMA != 1; then
+-    AC_MSG_NOTICE([Oniguruma was not found.])
+-    AC_MSG_NOTICE([ Try setting the location using '--with-oniguruma=PREFIX' ])
+-else
+-    AC_DEFINE([HAVE_ONIGURUMA],1,[Define to 1 if Oniguruma is installed])
+-fi
+-
++    [],
++    [with_oniguruma=yes])
++
++AS_IF([test "x$with_oniguruma" != xno], [
++    AS_IF([test "x$with_oniguruma" != xyes], [
++        CFLAGS="$CFLAGS -I${with_oniguruma}/include"
++        LDFLAGS="$LDFLAGS -L${with_oniguruma}/lib"
++    ])
++    # check for ONIGURUMA library
++    have_oniguruma=0
++    AC_CHECK_HEADER("oniguruma.h",
++        AC_CHECK_LIB([onig],[onig_version],[LIBS="$LIBS -lonig"; have_oniguruma=1;]))
++    # handle check results
++    AS_IF([test $have_oniguruma = 1], [
++        AC_DEFINE([HAVE_ONIGURUMA], 1, [Define to 1 if Oniguruma is installed])
++    ], [
++        AC_MSG_NOTICE([Oniguruma was not found.])
++        AC_MSG_NOTICE([Try setting the location using '--with-oniguruma=PREFIX'])
++    ])
++])
+ 
+ dnl Check for valgrind
+ AC_CHECK_PROGS(valgrind_cmd, valgrind)
+-- 
+1.9.1
+

--- a/meta-resin-krogoth/recipes-devtools/jq/jq_1.5.bbappend
+++ b/meta-resin-krogoth/recipes-devtools/jq/jq_1.5.bbappend
@@ -1,0 +1,11 @@
+
+
+FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
+
+SRC_URI += "file://Support-without-oniguruma.patch"
+
+DEPENDS_remove_class-native = "onig-native"
+
+EXTRA_OECONF_append_class-native = "--without-oniguruma"
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION

Yocto Pyro is much stricter on which host tools can be run from recipes. Add some missing dependencies to fix building with Pyro.
