### PR TITLE
Add support for building Docker with Pyro

### DIFF
--- a/meta-resin-common/recipes-containers/docker/docker_git.bb
+++ b/meta-resin-common/recipes-containers/docker/docker_git.bb
@@ -49,10 +49,12 @@ DEPENDS = " \
   systemd \
   "
 
-DEPENDS_append_class-target = "lvm2"
+DEPENDS_append_class-target = " lvm2"
 RDEPENDS_${PN} = "curl util-linux iptables tini systemd"
 RRECOMMENDS_${PN} += " kernel-module-dm-thin-pool kernel-module-nf-nat"
 DOCKER_PKG="github.com/docker/docker"
+
+inherit systemd go
 
 do_configure() {
 }
@@ -109,8 +111,6 @@ do_compile() {
 
   ./hack/make.sh binary-rce-docker
 }
-
-inherit systemd
 
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE_${PN} = "docker.service var-lib-docker.mount"

--- a/meta-resin-pyro/README.md
+++ b/meta-resin-pyro/README.md
@@ -1,0 +1,11 @@
+# Resin.io layer for pyro supported boards
+
+## Description
+This repository enables building resin.io for pyro supported machines.
+
+## Layer dependencies
+
+This layer depends on:
+
+* URI: git://git.yoctoproject.org/poky
+    * branch: pyro

--- a/meta-resin-pyro/conf/layer.conf
+++ b/meta-resin-pyro/conf/layer.conf
@@ -1,0 +1,8 @@
+BBPATH .= ":${LAYERDIR}"
+
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "resin-pyro"
+BBFILE_PATTERN_resin-pyro := "^${LAYERDIR}/"
+BBFILE_PRIORITY_resin-pyro = "1337"

--- a/meta-resin-pyro/recipes-containers/docker/docker_git.bbappend
+++ b/meta-resin-pyro/recipes-containers/docker/docker_git.bbappend
@@ -1,0 +1,1 @@
+DEPENDS_append_class-target = " libdevmapper"


### PR DESCRIPTION

A few minor changes to the Docker recipe to reflect changes in Yocto Pyro. We now use the built-in Go recipes and libdevmapper has been split out of lvm2.