### PR TITLE
NetworkManager Blocks Until Timeout During Startup // Fixed with gnutls 3.5.9

### DIFF
--- a/meta-resin-morty/recipes-support/gnutls/gnutls.inc
+++ b/meta-resin-morty/recipes-support/gnutls/gnutls.inc
@@ -1,0 +1,63 @@
+SUMMARY = "GNU Transport Layer Security Library"
+HOMEPAGE = "http://www.gnu.org/software/gnutls/"
+BUGTRACKER = "https://savannah.gnu.org/support/?group=gnutls"
+
+LICENSE = "GPLv3+ & LGPLv2.1+"
+LICENSE_${PN} = "LGPLv2.1+"
+LICENSE_${PN}-xx = "LGPLv2.1+"
+LICENSE_${PN}-bin = "GPLv3+"
+LICENSE_${PN}-openssl = "GPLv3+"
+
+LIC_FILES_CHKSUM = "file://LICENSE;md5=71391c8e0c1cfe68077e7fce3b586283 \
+                    file://doc/COPYING;md5=d32239bcb673463ab874e80d47fae504 \
+                    file://doc/COPYING.LESSER;md5=a6f89e2100d9b6cdffcea4f398e37343"
+
+DEPENDS = "nettle gmp virtual/libiconv libunistring"
+DEPENDS_append_libc-musl = " argp-standalone"
+
+SHRT_VER = "${@d.getVar('PV', True).split('.')[0]}.${@d.getVar('PV', True).split('.')[1]}"
+
+SRC_URI = "ftp://ftp.gnutls.org/gcrypt/gnutls/v${SHRT_VER}/gnutls-${PV}.tar.xz"
+
+inherit autotools texinfo binconfig pkgconfig gettext lib_package gtk-doc
+
+PACKAGECONFIG ??= "libidn zlib"
+
+# You must also have CONFIG_SECCOMP enabled in the kernel for
+# seccomp to work.
+#
+PACKAGECONFIG[seccomp] = "ac_cv_libseccomp=yes,ac_cv_libseccomp=no,libseccomp"
+
+PACKAGECONFIG[libidn] = "--with-idn,--without-idn,libidn"
+PACKAGECONFIG[libtasn1] = "--with-included-libtasn1=no,--with-included-libtasn1,libtasn1"
+PACKAGECONFIG[p11-kit] = "--with-p11-kit,--without-p11-kit,p11-kit"
+PACKAGECONFIG[tpm] = "--with-tpm,--without-tpm,trousers"
+PACKAGECONFIG[zlib] = "--with-zlib,--without-zlib,zlib"
+
+EXTRA_OECONF = " \
+    --enable-doc \
+    --disable-libdane \
+    --disable-guile \
+    --disable-rpath \
+    --enable-local-libopts \
+    --enable-openssl-compatibility \
+    --with-libpthread-prefix=${STAGING_DIR_HOST}${prefix} \
+    --without-libunistring-prefix \
+"
+
+LDFLAGS_append_libc-musl = " -largp"
+LDFLAGS_append_libc-uclibc = " -luargp -pthread"
+
+do_configure_prepend() {
+	for dir in . lib; do
+		rm -f ${dir}/aclocal.m4 ${dir}/m4/libtool.m4 ${dir}/m4/lt*.m4
+	done
+}
+
+PACKAGES =+ "${PN}-openssl ${PN}-xx"
+
+FILES_${PN}-dev += "${bindir}/gnutls-cli-debug"
+FILES_${PN}-openssl = "${libdir}/libgnutls-openssl.so.*"
+FILES_${PN}-xx = "${libdir}/libgnutlsxx.so.*"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-resin-morty/recipes-support/gnutls/gnutls/0001-configure.ac-fix-sed-command.patch
+++ b/meta-resin-morty/recipes-support/gnutls/gnutls/0001-configure.ac-fix-sed-command.patch
@@ -1,0 +1,32 @@
+From eaab55bb6d48643163eebbc9ca575a9ca2a8e03f Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Tue, 21 Feb 2017 17:10:07 +0200
+Subject: [PATCH] configure.ac: fix sed command
+
+The "sed 's/.bak//g'" matchs "bitbake", which would cause strange errors
+when the S contains "bitbake", fix to "sed 's/\.bak$//'`"
+
+Upstream-Status: Pending
+
+Signed-off-by: Robert Yang <liezhi.yang@windriver.com>
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 6907b21..7c70d9e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -948,7 +948,7 @@ YEAR=`date +%Y`
+ AC_SUBST([YEAR], $YEAR)
+ 
+ for i in ${srcdir}/src/*-args.c.bak ${srcdir}/src/*-args.h.bak; do
+-	nam=$(basename $i|sed 's/.bak//g')
++	nam=$(basename $i|sed 's/\.bak$//')
+ 	if test "$create_libopts_links" = "yes";then
+ 		rm -f "src/$nam"
+ 		AC_CONFIG_LINKS([src/$nam:$i])
+-- 
+2.11.0
+

--- a/meta-resin-morty/recipes-support/gnutls/gnutls/arm_eabi.patch
+++ b/meta-resin-morty/recipes-support/gnutls/gnutls/arm_eabi.patch
@@ -1,0 +1,19 @@
+Certain syscall's are not availabe for arm-eabi, so we eliminate
+reference to them.
+
+Upstream-Status: Pending
+
+Signed-off-by: Joe Slater <jslater@windriver.com>
+
+--- a/tests/seccomp.c
++++ b/tests/seccomp.c
+@@ -49,7 +49,9 @@ int disable_system_calls(void)
+ 	}
+ 
+ 	ADD_SYSCALL(nanosleep, 0);
++#if ! defined(__ARM_EABI__)
+ 	ADD_SYSCALL(time, 0);
++#endif
+ 	ADD_SYSCALL(getpid, 0);
+ 	ADD_SYSCALL(gettimeofday, 0);
+ #if defined(HAVE_CLOCK_GETTIME)

--- a/meta-resin-morty/recipes-support/gnutls/gnutls/correct_rpl_gettimeofday_signature.patch
+++ b/meta-resin-morty/recipes-support/gnutls/gnutls/correct_rpl_gettimeofday_signature.patch
@@ -1,0 +1,68 @@
+From 81b0f04c14f673b99778d2e7d8e85461e0bf2018 Mon Sep 17 00:00:00 2001
+From: Valentin Popa <valentin.popa@intel.com>
+Date: Fri, 25 Apr 2014 13:58:55 +0300
+Subject: [PATCH 1/3] Correct rpl_gettimeofday signature
+
+Currently we fail on uclibc like below
+
+| In file included from /home/kraj/work/angstrom/sources/openembedded-core/build/tmp-uclibc/sysroots/qemuarm/usr/include/sys/procfs.h:32:0,
+|                  from /home/kraj/work/angstrom/sources/openembedded-core/build/tmp-uclibc/sysroots/qemuarm/usr/include/sys/ucontext.h:26,
+|                  from /home/kraj/work/angstrom/sources/openembedded-core/build/tmp-uclibc/sysroots/qemuarm/usr/include/signal.h:392,
+|                  from ../../gl/signal.h:52,
+|                  from ../../gl/sys/select.h:58,
+|                  from /home/kraj/work/angstrom/sources/openembedded-core/build/tmp-uclibc/sysroots/qemuarm/usr/include/sys/types.h:220,
+|                  from ../../gl/sys/types.h:28,
+|                  from ../../lib/includes/gnutls/gnutls.h:46,
+|                  from ex-cxx.cpp:3:
+| ../../gl/sys/time.h:396:66: error: conflicting declaration 'void* restrict'
+| ../../gl/sys/time.h:396:50: error: 'restrict' has a previous declaration as 'timeval* restrict'
+| make[4]: *** [ex-cxx.o] Error 1
+| make[4]: *** Waiting for unfinished jobs....
+
+GCC detects that we call 'restrict' as param name in function
+signatures and complains since both params are called 'restrict'
+therefore we use __restrict to denote the C99 keywork
+
+This only happens of uclibc since this code is not excercised with
+eglibc otherwise we will have same issue there too
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Upstream-Status: Pending
+
+---
+ gl/sys_time.in.h | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/gl/sys_time.in.h b/gl/sys_time.in.h
+index 5a8caf3..2dc5718 100644
+--- a/gl/sys_time.in.h
++++ b/gl/sys_time.in.h
+@@ -93,20 +93,20 @@ struct timeval
+ #   define gettimeofday rpl_gettimeofday
+ #  endif
+ _GL_FUNCDECL_RPL (gettimeofday, int,
+-                  (struct timeval *restrict, void *restrict)
++                  (struct timeval *__restrict, void *__restrict)
+                   _GL_ARG_NONNULL ((1)));
+ _GL_CXXALIAS_RPL (gettimeofday, int,
+-                  (struct timeval *restrict, void *restrict));
++                  (struct timeval *__restrict, void *__restrict));
+ # else
+ #  if !@HAVE_GETTIMEOFDAY@
+ _GL_FUNCDECL_SYS (gettimeofday, int,
+-                  (struct timeval *restrict, void *restrict)
++                  (struct timeval *__restrict, void *__restrict)
+                   _GL_ARG_NONNULL ((1)));
+ #  endif
+ /* Need to cast, because on glibc systems, by default, the second argument is
+                                                   struct timezone *.  */
+ _GL_CXXALIAS_SYS_CAST (gettimeofday, int,
+-                       (struct timeval *restrict, void *restrict));
++                       (struct timeval *__restrict, void *__restrict));
+ # endif
+ _GL_CXXALIASWARN (gettimeofday);
+ # if defined __cplusplus && defined GNULIB_NAMESPACE
+-- 
+2.10.2
+

--- a/meta-resin-morty/recipes-support/gnutls/gnutls/use-pkg-config-to-locate-zlib.patch
+++ b/meta-resin-morty/recipes-support/gnutls/gnutls/use-pkg-config-to-locate-zlib.patch
@@ -1,0 +1,67 @@
+From cee80af1fe93f5b76765afeebfcc3b902768f5d6 Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Tue, 26 May 2015 21:41:24 -0700
+Subject: [PATCH] use pkg-config to locate zlib
+
+AC_LIB_HAVE_LINKFLAGS can sometimes find host libs and is therefore not
+robust when cross-compiling. Remove it for zlib and use PKG_CHECK_MODULES
+instead.
+
+Removing AC_LIB_HAVE_LINKFLAGS for zlib also removes the --with-libz-prefix
+configure option. If zlib support is enabled, then failure to find zlib via
+pkg-config is now treated as a fatal error.
+
+Change based on ChromeOS gnutls 2.12.23 cross-compile fixes patch:
+
+  https://chromium-review.googlesource.com/#/c/271661/
+
+Upstream-Status: Inappropriate [configuration]
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+---
+ configure.ac | 24 ++++++++++--------------
+ 1 file changed, 10 insertions(+), 14 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 1b561d5..0c787dc 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -508,25 +508,21 @@ AC_ARG_WITH(zlib, AS_HELP_STRING([--without-zlib],
+ AC_MSG_CHECKING([whether to include zlib compression support])
+ if test x$ac_zlib != xno; then
+  AC_MSG_RESULT(yes)
+- AC_LIB_HAVE_LINKFLAGS(z,, [#include <zlib.h>], [compress (0, 0, 0, 0);])
+- if test x$ac_cv_libz != xyes; then
+-   AC_MSG_WARN(
+-*** 
+-*** ZLIB was not found. You will not be able to use ZLIB compression.)
+- fi
+ else
+  AC_MSG_RESULT(no)
+ fi
+ 
+-PKG_CHECK_EXISTS(zlib, ZLIB_HAS_PKGCONFIG=y, ZLIB_HAS_PKGCONFIG=n)
+-
+ if test x$ac_zlib != xno; then
+-  if test "$ZLIB_HAS_PKGCONFIG" = "y" ; then
+-    if test "x$GNUTLS_REQUIRES_PRIVATE" = x; then
+-      GNUTLS_REQUIRES_PRIVATE="Requires.private: zlib"
+-    else
+-      GNUTLS_REQUIRES_PRIVATE="$GNUTLS_REQUIRES_PRIVATE, zlib"
+-    fi
++  PKG_CHECK_MODULES(ZLIB, zlib)
++  HAVE_LIBZ=yes
++  AC_DEFINE([HAVE_LIBZ], [1], [zlib is enabled])
++  AC_SUBST(HAVE_LIBZ)
++  LTLIBZ=$ZLIB_LIBS
++  AC_SUBST(LTLIBZ)
++  if test "x$GNUTLS_REQUIRES_PRIVATE" = x; then
++    GNUTLS_REQUIRES_PRIVATE="Requires.private: zlib"
++  else
++    GNUTLS_REQUIRES_PRIVATE="$GNUTLS_REQUIRES_PRIVATE, zlib"
+   fi
+ fi
+ AC_SUBST(GNUTLS_REQUIRES_PRIVATE)
+-- 
+1.9.1
+

--- a/meta-resin-morty/recipes-support/gnutls/gnutls_3.5.9.bb
+++ b/meta-resin-morty/recipes-support/gnutls/gnutls_3.5.9.bb
@@ -1,0 +1,10 @@
+require gnutls.inc
+
+SRC_URI += " file://correct_rpl_gettimeofday_signature.patch \
+            file://0001-configure.ac-fix-sed-command.patch \
+            file://use-pkg-config-to-locate-zlib.patch \
+            file://arm_eabi.patch \
+           "
+SRC_URI[md5sum] = "0ab25eb6a1509345dd085bc21a387951"
+SRC_URI[sha256sum] = "82b10f0c4ef18f4e64ad8cef5dbaf14be732f5095a41cf366b4ecb4050382951"
+

--- a/meta-resin-morty/recipes-support/gnutls/libtasn1/0001-stdint.m4-reintroduce-GNULIB_OVERRIDES_WINT_T-check.patch
+++ b/meta-resin-morty/recipes-support/gnutls/libtasn1/0001-stdint.m4-reintroduce-GNULIB_OVERRIDES_WINT_T-check.patch
@@ -1,0 +1,63 @@
+From b17dbb8d3c5605db3a1d82861fcaeef4636d1117 Mon Sep 17 00:00:00 2001
+From: "Maxin B. John" <maxin.john@intel.com>
+Date: Thu, 26 Jan 2017 18:54:48 +0200
+Subject: [PATCH] stdint.m4: reintroduce GNULIB_OVERRIDES_WINT_T check
+
+Partially revert the gnulib commit: 5a400b3f5a1f5483dbfd75d38bdb7080218a063b
+to fix the build error with musl library.
+
+Upstream-Status: Inappropriate
+
+Signed-off-by: Maxin B. John <maxin.john@intel.com>
+---
+ gl/m4/stdint.m4 | 27 +++++++++++++++++++++++++++
+ 1 file changed, 27 insertions(+)
+
+diff --git a/gl/m4/stdint.m4 b/gl/m4/stdint.m4
+index 4ac854d..3dc3da1 100644
+--- a/gl/m4/stdint.m4
++++ b/gl/m4/stdint.m4
+@@ -355,6 +355,32 @@ int32_t i32 = INT32_C (0x7fffffff);
+     gl_STDINT_TYPE_PROPERTIES
+   fi
+ 
++  dnl Determine whether gnulib's <wchar.h> or <wctype.h> would, if present,
++  dnl override 'wint_t'.
++    AC_CACHE_CHECK([whether wint_t is too small],
++      [gl_cv_type_wint_t_too_small],
++      [AC_COMPILE_IFELSE(
++           [AC_LANG_PROGRAM([[
++  /* Tru64 with Desktop Toolkit C has a bug: <stdio.h> must be included before
++     <wchar.h>.
++     BSD/OS 4.0.1 has a bug: <stddef.h>, <stdio.h> and <time.h> must be
++     included before <wchar.h>.  */
++  #if !(defined __GLIBC__ && !defined __UCLIBC__)
++  # include <stddef.h>
++  # include <stdio.h>
++  # include <time.h>
++  #endif
++  #include <wchar.h>
++              int verify[sizeof (wint_t) < sizeof (int) ? -1 : 1];
++              ]])],
++           [gl_cv_type_wint_t_too_small=no],
++           [gl_cv_type_wint_t_too_small=yes])])
++    if test $gl_cv_type_wint_t_too_small = yes; then
++      GNULIB_OVERRIDES_WINT_T=1
++    else
++      GNULIB_OVERRIDES_WINT_T=0
++    fi
++
+   dnl The substitute stdint.h needs the substitute limit.h's _GL_INTEGER_WIDTH.
+   LIMITS_H=limits.h
+   AM_CONDITIONAL([GL_GENERATE_LIMITS_H], [test -n "$LIMITS_H"])
+@@ -363,6 +389,7 @@ int32_t i32 = INT32_C (0x7fffffff);
+   AC_SUBST([HAVE_SYS_BITYPES_H])
+   AC_SUBST([HAVE_SYS_INTTYPES_H])
+   AC_SUBST([STDINT_H])
++  AC_SUBST([GNULIB_OVERRIDES_WINT_T])
+   AM_CONDITIONAL([GL_GENERATE_STDINT_H], [test -n "$STDINT_H"])
+ ])
+ 
+-- 
+2.4.0
+

--- a/meta-resin-morty/recipes-support/gnutls/libtasn1/dont-depend-on-help2man.patch
+++ b/meta-resin-morty/recipes-support/gnutls/libtasn1/dont-depend-on-help2man.patch
@@ -1,0 +1,14 @@
+Upstream-Status: Inappropriate
+
+Signed-off-by: Marko Lindqvist <cazfi74@gmail.com>
+diff -Nurd libtasn1-2.14/doc/Makefile.am libtasn1-2.14/doc/Makefile.am
+--- libtasn1-2.14/doc/Makefile.am	2012-09-24 15:08:42.000000000 +0300
++++ libtasn1-2.14/doc/Makefile.am	2013-01-03 07:35:26.702763403 +0200
+@@ -31,7 +31,7 @@
+ AM_MAKEINFOHTMLFLAGS = $(AM_MAKEINFOFLAGS) \
+	--no-split --number-sections --css-include=texinfo.css
+
+-dist_man_MANS = $(gdoc_MANS) asn1Parser.1 asn1Coding.1 asn1Decoding.1
++dist_man_MANS = $(gdoc_MANS)
+
+ HELP2MAN_OPTS = --info-page libtasn1

--- a/meta-resin-morty/recipes-support/gnutls/libtasn1_4.10.bb
+++ b/meta-resin-morty/recipes-support/gnutls/libtasn1_4.10.bb
@@ -1,0 +1,23 @@
+SUMMARY = "Library for ASN.1 and DER manipulation"
+HOMEPAGE = "http://www.gnu.org/software/libtasn1/"
+
+LICENSE = "GPLv3+ & LGPLv2.1+"
+LICENSE_${PN}-bin = "GPLv3+"
+LICENSE_${PN} = "LGPLv2.1+"
+LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504 \
+                    file://COPYING.LIB;md5=4fbd65380cdd255951079008b364516c \
+                    file://README;endline=8;md5=c3803a3e8ca5ab5eb1e5912faa405351"
+
+SRC_URI = "${GNU_MIRROR}/libtasn1/libtasn1-${PV}.tar.gz \
+           file://dont-depend-on-help2man.patch \
+           file://0001-stdint.m4-reintroduce-GNULIB_OVERRIDES_WINT_T-check.patch \
+           "
+
+DEPENDS = "bison-native"
+
+SRC_URI[md5sum] = "f4faffdf63969d0e4e6df43b9679e8e5"
+SRC_URI[sha256sum] = "681a4d9a0d259f2125713f2e5766c5809f151b3a1392fd91390f780b4b8f5a02"
+
+inherit autotools texinfo binconfig lib_package gtk-doc
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
gnutls: Update to 3.5.9 in morty

The NetworkManager loads the gnutls library which calls on initialisation getrandom(). This call blocks until the entropy level is high enough in the system to initialise the random number pool, see #831. This delays the start of the NetworkManager, and in our case until the timeout of 1.5 minutes is reached. There is no need for gnutls to call getrandom() during initialisation because at this stage no en- or decryption operation is called. In gnutls 3.5.9 and newer, this issue is fixed. Unfortunately, this version isn't part of morty, yet. Therefore, if you update to NetworkManager 1.8, then you should also update the gnutls library.

Changelog-entry: Update gnutls to 3.5.9 in morty because of blocking NetworkManager
Change-type: patch
Signed-off-by: Robert Fritzsche <r.fritzsche@gridx.de>