### PR TITLE
meta-resin-pyro: Add packagegroup-resin-connectivity

### DIFF
--- a/meta-resin-pyro/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
+++ b/meta-resin-pyro/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
@@ -1,0 +1,21 @@
+CONNECTIVITY_FIRMWARES_append = " \
+    linux-firmware-bcm43143 \
+    linux-firmware-iwlwifi-135-6 \
+    linux-firmware-iwlwifi-3160-7 \
+    linux-firmware-iwlwifi-3160-8 \
+    linux-firmware-iwlwifi-3160-9 \
+    linux-firmware-iwlwifi-6000-4 \
+    linux-firmware-iwlwifi-6000g2a-5 \
+    linux-firmware-iwlwifi-6000g2a-6 \
+    linux-firmware-iwlwifi-6000g2b-5 \
+    linux-firmware-iwlwifi-6000g2b-6 \
+    linux-firmware-iwlwifi-6050-4 \
+    linux-firmware-iwlwifi-6050-5 \
+    linux-firmware-iwlwifi-7260 \
+    linux-firmware-iwlwifi-7265 \
+    linux-firmware-iwlwifi-7265d \
+    linux-firmware-iwlwifi-8000c \
+    linux-firmware-iwlwifi-8265 \
+    linux-firmware-rtl8188eu \
+    linux-firmware-wl12xx \
+    "


### PR DESCRIPTION
Include firmwares in the Pyro version of the OS.

Change-type: minor
Changelog-entry: Include connectivity firmwares in Pyro
Signed-off-by: Will Newton <willn@resin.io>