### PR TITLE
docker-disk.inc: Set DOCKER_API_VERSION to 1.22

### DIFF
--- a/meta-resin-common/recipes-containers/docker-disk/docker-disk.inc
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-disk.inc
@@ -34,8 +34,8 @@ do_compile () {
     # Make sure there is at least one available loop device
     losetup -f > /dev/null 2>&1 || bbfatal "docker-disk: Host must have at least one available loop device."
 
-    docker build -t looper -f ${WORKDIR}/Dockerfile ${WORKDIR}
-    docker run --rm --privileged -e DOCKER_STORAGE=${DOCKER_STORAGE} -e PARTITION_SIZE=${PARTITION_SIZE} -e TARGET_REPOSITORY=${TARGET_REPOSITORY} -e TARGET_TAG=${TARGET_TAG} -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v ${B}:/export looper
+    DOCKER_API_VERSION=1.22 docker build -t looper -f ${WORKDIR}/Dockerfile ${WORKDIR}
+    DOCKER_API_VERSION=1.22 docker run --rm --privileged -e DOCKER_STORAGE=${DOCKER_STORAGE} -e PARTITION_SIZE=${PARTITION_SIZE} -e TARGET_REPOSITORY=${TARGET_REPOSITORY} -e TARGET_TAG=${TARGET_TAG} -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v ${B}:/export looper
 }
 do_compile[vardeps] += "PARTITION_SIZE TARGET_REPOSITORY TARGET_TAG"
 


### PR DESCRIPTION
Compiling on hosts that have different docker versions installed yields errors like:

Error response from daemon: client is newer than server (client API version: 1.24, server API version: 1.22)

Basing on the fact that the API is backward compatible, we fix the client version API at 1.22

Change-type: patch
Changelog-entry: Set DOCKER_API_VERSION to 1.22 for docker-disk.inc
Signed-off-by: Florin Sarbu <florin@resin.io>