### PR TITLE
resin-os.inc: Add security flags

### DIFF
--- a/meta-resin-common/conf/distro/include/resin-os.inc
+++ b/meta-resin-common/conf/distro/include/resin-os.inc
@@ -1,5 +1,6 @@
 # Poky based distro file
 require conf/distro/poky.conf
+require conf/distro/include/security_flags.inc
 
 DISTRO = "resin-os"
 DISTRO_NAME = "Resin OS"

--- a/meta-resin-common/recipes-containers/tini/tini_0.14.0.bb
+++ b/meta-resin-common/recipes-containers/tini/tini_0.14.0.bb
@@ -18,6 +18,9 @@ S = "${WORKDIR}/git"
 
 BBCLASSEXTEND = "native"
 
+# tini links with -static, so no PIE for us
+SECURITY_CFLAGS_pn-${PN} = "${SECURITY_NO_PIE_CFLAGS}"
+
 inherit cmake
 
 do_install() {


### PR DESCRIPTION
Enable Yocto security flags such as stack protector, fortify and
Position Independent Executables.

Change-type: minor
Changelog-entry: Enable Yocto security flags on all builds
Signed-off-by: Will Newton <willn@resin.io>