### PR TITLE
kernel-resin.bbclass: Enable strong stack protector

### DIFF
--- a/meta-resin-common/classes/kernel-resin.bbclass
+++ b/meta-resin-common/classes/kernel-resin.bbclass
@@ -83,6 +83,7 @@ RESIN_CONFIGS ?= " \
     misc \
     redsocks \
     reduce-size \
+    security \
     ${DOCKER_STORAGE} \
     "
 
@@ -378,6 +379,13 @@ RESIN_CONFIGS[reduce-size] = " \
     CONFIG_UDF_FS=n \
     CONFIG_BLK_DEV_DRBD=n \
     "
+
+# security features
+RESIN_CONFIGS[security] = " \
+    CONFIG_CC_STACKPROTECTOR=y \
+    CONFIG_CC_STACKPROTECTOR_STRONG=y \
+    "
+
 ###########
 # HELPERS #
 ###########


### PR DESCRIPTION
Enable stack protection in the kernel by default. This requires
gcc 4.9 and kernel 3.14.

Change-type: minor
Changelog-entry: Enable kernel stack protection
Signed-off-by: Will Newton <willn@resin.io>