### PR TITLE
1.x resinhup improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Resinhup: allow cached pull of the resinhup updater container as well [Gergely]
 * Resinhup: run supervisor update to the release version by default and add negative flag [Gergely]
 * Resinhup: fix update failure on Intel NUC due to partition matching [Gergely]
 * Update supervisor to v6.2.5 [Pablo]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Resinhup: run supervisor update to the release version by default and add negative flag [Gergely]
 * Resinhup: fix update failure on Intel NUC due to partition matching [Gergely]
 * Update supervisor to v6.2.5 [Pablo]
 

--- a/meta-resin-common/recipes-support/resinhup/resinhup/run-resinhup.sh
+++ b/meta-resin-common/recipes-support/resinhup/resinhup/run-resinhup.sh
@@ -12,6 +12,7 @@ CACHE=no
 MAXRETRIES=5
 SCRIPTNAME=run-resinhup.sh
 DEFAULT_CURRENT_HOSTOS_VERSION=1.0.0
+SUPERVISOR_RELEASE_UPDATE=yes
 
 # Don't run anything before this source as it sets PATH here
 source /etc/profile
@@ -54,9 +55,12 @@ Options:
         Before updating ResinOS, update Supervisor using this tag.
         Don't omit the 'v' in front of the version. e.g.: v1.2.3 and not 1.2.3.
 
-  --supervisor-release-update
-        Update the supervisor to the version that ships with the target host OS
-        releases, if that is newer than the version run by the device.
+  --no-supervisor-release-update
+        By default the script updates the supervisor to the version that ships
+        with the target host OS releases, if that is newer than the version run
+        on the device. This tag switches this default update method, and no
+        supervisor update is performed, unless a version tag is provided (see
+        the previous option).
 
   --only-supervisor
         Update only the supervisor.
@@ -497,10 +501,11 @@ while [[ $# -gt 0 ]]; do
                 log ERROR "\"$1\" argument needs a value."
             fi
             UPDATER_SUPERVISOR_TAG=$2
+            SUPERVISOR_RELEASE_UPDATE=no
             shift
             ;;
-        --supervisor-release-update)
-            SUPERVISOR_RELEASE_UPDATE=yes
+        --no-supervisor-release-update)
+            SUPERVISOR_RELEASE_UPDATE=no
             ;;
         --only-supervisor)
             ONLY_SUPERVISOR=yes
@@ -631,7 +636,7 @@ log "Removing all containers..."
 $DOCKER rm $($DOCKER ps -a -q) > /dev/null 2>&1
 
 # Supervisor update
-if [ ! -z "$SUPERVISOR_RELEASE_UPDATE" ]; then
+if [ "$SUPERVISOR_RELEASE_UPDATE" == "yes" ]; then
     getSupervisorVersionFromRelease
 fi
 if [ ! -z "$UPDATER_SUPERVISOR_TAG" ]; then

--- a/meta-resin-common/recipes-support/resinhup/resinhup/run-resinhup.sh
+++ b/meta-resin-common/recipes-support/resinhup/resinhup/run-resinhup.sh
@@ -234,7 +234,7 @@ function runPostHacks {
         if [ "$DOCKER" == "rce" ]; then
             log "Running engine migrator 1.10... please wait..."
             DOCKER_MIGRATOR="registry.resinstaging.io/resinhup/$arch-v1.10-migrator"
-            retrycommand "$DOCKER pull $DOCKER_MIGRATOR"
+            cachedpull "$DOCKER_MIGRATOR"
             $DOCKER run --rm -v /var/lib/rce:/var/lib/docker $DOCKER_MIGRATOR -s btrfs
             if [ $? -eq 0 ]; then
                 log "Migration to engine 1.10 done."

--- a/scripts/resinhup/run-resinhup-ssh.sh
+++ b/scripts/resinhup/run-resinhup-ssh.sh
@@ -59,8 +59,8 @@ Options:
         Run run-resinhup.sh with this --supervisor-tag argument. See run-resinhup.sh
         help for more details.
 
-  --supervisor-release-update
-        Run run-resinhup.sh with --supervisor-release-update . See run-resinhup.sh help for more details.
+  --no-supervisor-release-update
+        Run run-resinhup.sh with --no-supervisor-release-update . See run-resinhup.sh help for more details.
 
   --only-supervisor
         Update only the supervisor.
@@ -269,8 +269,8 @@ while [[ $# -gt 0 ]]; do
             RESINHUP_ARGS="$RESINHUP_ARGS --supervisor-tag $SUPERVISOR_TAG"
             shift
             ;;
-        --supervisor-release-update)
-            RESINHUP_ARGS="$RESINHUP_ARGS --supervisor-release-update"
+        --no-supervisor-release-update)
+            RESINHUP_ARGS="$RESINHUP_ARGS --no-supervisor-release-update"
             ;;
         --resinhup-tag)
             if [ -z "$2" ]; then


### PR DESCRIPTION
Two changes in this PR:

* make supervisor update default behaviour (no flag needed), and update the flags to be able to disable this behaviour, and handle supervisor tag setting properly
* allow resinhup updater container to be cached like it is already possible for the other containers that are used in the update process (supervisor and resinOS)