### PR TITLE
bluez5.bbappend: Add udev rule to bring hci0 up

### DIFF
--- a/meta-resin-common/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/meta-resin-common/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS_append := ":${THISDIR}/files"
+
+SRC_URI += "file://10-local-bt-hci-up.rules"
+
+do_install_append() {
+    install -D -m 0755 ${WORKDIR}/10-local-bt-hci-up.rules ${D}/etc/udev/rules.d/10-local-bt-hci-up.rules
+}

--- a/meta-resin-common/recipes-connectivity/bluez5/files/10-local-bt-hci-up.rules
+++ b/meta-resin-common/recipes-connectivity/bluez5/files/10-local-bt-hci-up.rules
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="bluetooth", KERNEL=="hci[0-9]*", RUN+="/usr/bin/hciconfig %k up"


### PR DESCRIPTION
There are boards which boot with hci0 brought down. By adding this rule
we make sure bluetooth is functional once the board has booted.

Change-type: patch
Changelog-entry: Make sure hci0 bluetooth interface is activated once booted
Signed-off-by: Florin Sarbu <florin@resin.io>