### PR TITLE
kernel-resin: Enable zram

### DIFF
--- a/meta-resin-common/classes/kernel-resin.bbclass
+++ b/meta-resin-common/classes/kernel-resin.bbclass
@@ -84,6 +84,7 @@ RESIN_CONFIGS ?= " \
     redsocks \
     reduce-size \
     security \
+    zram \
     ${DOCKER_STORAGE} \
     "
 
@@ -384,6 +385,14 @@ RESIN_CONFIGS[reduce-size] = " \
 RESIN_CONFIGS[security] = " \
     CONFIG_CC_STACKPROTECTOR=y \
     CONFIG_CC_STACKPROTECTOR_STRONG=y \
+    "
+
+# zram provides a compressed in-memory swap device
+RESIN_CONFIGS[zram] = " \
+    CONFIG_ZSMALLOC=m \
+    CONFIG_ZRAM=m \
+    CONFIG_CRYPTO=y \
+    CONFIG_CRYPTO_LZO=m \
     "
 
 ###########


### PR DESCRIPTION
Enable the zram kernelmodule by default. This provides an
in-memory compressed swap device which can alleviate problems
with memory pressure on memory constrained devices and is enabled
by default on Chromebooks.

Change-type: minor
Changelog-entry: Enable zram kernel module by default
Signed-off-by: Will Newton <willn@resin.io>