### PR TITLE
config.json: Sort keys when processing with jq

### DIFF
--- a/meta-resin-common/classes/image-resin.bbclass
+++ b/meta-resin-common/classes/image-resin.bbclass
@@ -43,7 +43,7 @@ init_config_json() {
    echo '{}' > ${1}/config.json
 
    # Default no to persistent-logging
-   echo $(cat ${1}/config.json | jq ".persistentLogging=false") > ${1}/config.json
+   echo $(cat ${1}/config.json | jq -S ".persistentLogging=false") > ${1}/config.json
 
    # Find board json and extract slug
    common_path=$(echo "${BBLAYERS}" | grep -o -E '[^ ]+meta-resin-common')
@@ -51,10 +51,10 @@ init_config_json() {
    slug=$(jq .slug $json_path)
 
    # Set deviceType for supervisor
-   echo $(cat ${1}/config.json | jq ".deviceType=$slug") > ${1}/config.json
+   echo $(cat ${1}/config.json | jq -S ".deviceType=$slug") > ${1}/config.json
 
    if ${@bb.utils.contains('DISTRO_FEATURES','development-image','true','false',d)}; then
-       echo $(cat ${1}/config.json | jq ".hostname=\"resin\"") > ${1}/config.json
+       echo $(cat ${1}/config.json | jq -S ".hostname=\"resin\"") > ${1}/config.json
    fi
 }
 

--- a/meta-resin-common/recipes-support/resin-device-register/resin-device-register/resin-device-register
+++ b/meta-resin-common/recipes-support/resin-device-register/resin-device-register/resin-device-register
@@ -63,7 +63,7 @@ while true; do
         if [ "$status_code" -eq 201 ]; then
             device_id=$(jq -r '.id' $LOG_FILE)
             config_json=$(cat "$CONFIG_PATH")
-            echo "$config_json" | jq ".registered_at=\"$(date +%s)\"|.deviceId=\"$device_id\"" > "$CONFIG_PATH"
+            echo "$config_json" | jq -S ".registered_at=\"$(date +%s)\"|.deviceId=\"$device_id\"" > "$CONFIG_PATH"
             echo "[INFO] resin-device-register : Registered device with ID: $device_id and UUID: $uuid."
             exit 0
         else


### PR DESCRIPTION
Pass the -S flag to jq to sort the keys in config.json. This
makes the output reproducible and easier for humans to read.

This fixes the kernel rebuild issue for me.

Change-type: patch
Changelog-entry: Sort config.json keys
Signed-off-by: Will Newton <willn@resin.io>