### PR TITLE
kernel-modules-headers: Use STAGING_KERNEL_BUILDDIR for .config

### DIFF
--- a/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
+++ b/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
@@ -25,7 +25,7 @@ do_configure[noexec] = "1"
 
 do_compile() {
     mkdir -p kernel_modules_headers
-    ${S}/gen_mod_headers ./kernel_modules_headers ${STAGING_KERNEL_DIR} ${DEPLOY_DIR_IMAGE} ${ARCH} ${TARGET_PREFIX} "${CC}"
+    ${S}/gen_mod_headers ./kernel_modules_headers ${STAGING_KERNEL_DIR} ${STAGING_KERNEL_BUILDDIR} ${ARCH} ${TARGET_PREFIX} "${CC}"
     tar -czf kernel_modules_headers.tar.gz kernel_modules_headers
     rm -rf kernel_modules_headers
 }


### PR DESCRIPTION
When trying to locate the .config use STAGING_KERNEL_BUIDLDIR
instead of DEPLOY_DIR_IMAGE. This seems to be required with
some kernels, e.g. resin-intel.

Change-type: patch
Changelog-entry: Use STAGING_KERNEL_BUILDDIR for kernel .config
Signed-off-by: Will Newton <willn@resin.io>