### PR TITLE
update-resin-supervisor: device API key is substituted incorrectly

### DIFF
--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/update-resin-supervisor
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/update-resin-supervisor
@@ -61,7 +61,7 @@ if [ -z "$API_ENDPOINT" ]; then
 fi
 
 # If the user api key exists we use it instead of the deviceApiKey as it means we haven't done the key exchange yet
-_device_api_key=${PROVISIONING_API_KEY:-DEVICE_API_KEY}
+_device_api_key=${PROVISIONING_API_KEY:-$DEVICE_API_KEY}
 if [ -z "$_device_api_key" -o -z "$DEVICE_ID" ]; then
     echo "PROVISIONING_API_KEY or DEVICE_API_KEY, and DEVICE_ID variables must be set."
     exit 1


### PR DESCRIPTION
Same issue as in the `resin-device-progress` script, fixed in https://github.com/resin-os/meta-resin/pull/791

This basically makes update-resin-supervisor unable to pull a supervisor based on API response, as the API call is done incorrectly using the device API key.