### PR TITLE
docker: Inherit pkgconfig

### DIFF
--- a/meta-resin-common/recipes-containers/docker/docker_git.bb
+++ b/meta-resin-common/recipes-containers/docker/docker_git.bb
@@ -47,7 +47,7 @@ RDEPENDS_${PN}_class-target = "curl util-linux iptables tini systemd"
 RRECOMMENDS_${PN} += " kernel-module-nf-nat"
 DOCKER_PKG="github.com/docker/docker"
 
-inherit systemd go
+inherit systemd go pkgconfig
 
 # oe-meta-go recipes try to build go-cross-native
 DEPENDS_remove_class-native = "go-cross-native"


### PR DESCRIPTION
If pkgconfig is not part of the recipe sysroot then the docker
build scripts will just plough ahead and get things wrong.

Change-type: patch
Changelog-entry: Ensure docker links with systemd in pyro
Signed-off-by: Will Newton <willn@resin.io>