### PR TITLE
dnsmasq: Upgrade to 2.78

### DIFF
--- a/meta-resin-common/recipes-connectivity/dnsmasq/dnsmasq_2.78.bb
+++ b/meta-resin-common/recipes-connectivity/dnsmasq/dnsmasq_2.78.bb
@@ -1,18 +1,15 @@
-FILESEXTRAPATHS_append := ":${THISDIR}/files"
+require recipes-support/dnsmasq/dnsmasq.inc
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI_append = " \
-    file://dnsmasq.conf \
+    file://lua.patch \
     file://dnsmasq.conf.systemd \
     file://resolv.conf \
     "
 
-# for dnsmasq versions older than 2.76 we need to still apply the following patch:
-python() {
-    packageVersion = d.getVar('PV', True)
-    srcURI = d.getVar('SRC_URI', True)
-    if packageVersion < '2.76':
-        d.setVar('SRC_URI', srcURI + ' ' + 'file://0001-Treat-REFUSED-not-SERVFAIL-as-an-unsuccessful-upstre.patch')
-}
+SRC_URI[dnsmasq-2.78.md5sum] = "3bb97f264c73853f802bf70610150788"
+SRC_URI[dnsmasq-2.78.sha256sum] = "c92e5d78aa6353354d02aabf74590d08980bb1385d8a00b80ef9bc80430aa1dc"
 
 do_install_append() {
     if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then

--- a/meta-resin-common/recipes-connectivity/dnsmasq/files/99_dnsmasq
+++ b/meta-resin-common/recipes-connectivity/dnsmasq/files/99_dnsmasq
@@ -1,0 +1,1 @@
+d root root 0755 /run/dnsmasq none

--- a/meta-resin-common/recipes-connectivity/dnsmasq/files/dnsmasq-noresolvconf.service
+++ b/meta-resin-common/recipes-connectivity/dnsmasq/files/dnsmasq-noresolvconf.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=DNS forwarder and DHCP server
+After=network.target
+
+[Service]
+Type=forking
+PIDFile=/run/dnsmasq.pid
+ExecStartPre=/usr/bin/dnsmasq --test
+ExecStart=/usr/bin/dnsmasq -x /run/dnsmasq.pid -7 /etc/dnsmasq.d --local-service
+ExecStop=/bin/kill $MAINPID
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target
+

--- a/meta-resin-common/recipes-connectivity/dnsmasq/files/dnsmasq-resolvconf-helper
+++ b/meta-resin-common/recipes-connectivity/dnsmasq/files/dnsmasq-resolvconf-helper
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# Borrowing heavily from the dnsmasq initscript's version of support for
+# resolvconf, intended for use in systemd-only configurations.
+#
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DAEMON=/usr/sbin/dnsmasq
+NAME=dnsmasq
+
+# Most configuration options in /etc/default/dnsmasq are deprecated
+# but still honoured.
+if [ -r /etc/default/$NAME ]; then
+   . /etc/default/$NAME
+fi
+
+start_resolvconf()
+{
+   # If interface "lo" is explicitly disabled in /etc/default/dnsmasq
+   # Then dnsmasq won't be providing local DNS, so don't add it to
+   # the resolvconf server set.
+   for interface in $DNSMASQ_EXCEPT
+   do
+      [ $interface = lo ] && return
+   done
+
+   if [ -x /sbin/resolvconf ] ; then
+      echo "nameserver 127.0.0.1" |
+      /sbin/resolvconf -a lo.$NAME
+   fi
+   return 0
+}
+
+stop_resolvconf()
+{
+   if [ -x /sbin/resolvconf ] ; then
+      /sbin/resolvconf -d lo.$NAME
+   fi
+   return 0
+}
+
+case "$1" in
+   start)
+      start_resolvconf
+      exit 0
+      ;;
+   stop)
+      stop_resolvconf
+      exit 0
+      ;;
+   restart)
+      stop_resolvconf
+      start_resolvconf
+      exit 0
+      ;;
+   *)
+      echo "Usage: /etc/init.d/$NAME {start|stop|restart}" >&2
+      exit 3
+      ;;
+esac
+
+exit 0
+

--- a/meta-resin-common/recipes-connectivity/dnsmasq/files/dnsmasq-resolvconf.service
+++ b/meta-resin-common/recipes-connectivity/dnsmasq/files/dnsmasq-resolvconf.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=DNS forwarder and DHCP server
+After=network.target
+
+[Service]
+Type=forking
+PIDFile=/run/dnsmasq.pid
+ExecStartPre=/usr/bin/dnsmasq --test
+ExecStart=/usr/bin/dnsmasq -x /run/dnsmasq.pid -7 /etc/dnsmasq.d --local-service
+ExecStartPost=/usr/bin/dnsmasq-resolvconf-helper start
+ExecStopPre=/usr/bin/dnsmasq-resolvconf-helper stop
+ExecStop=/bin/kill $MAINPID
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target
+

--- a/meta-resin-common/recipes-connectivity/dnsmasq/files/dnsmasq.conf
+++ b/meta-resin-common/recipes-connectivity/dnsmasq/files/dnsmasq.conf
@@ -4,6 +4,11 @@
 # as the long options legal on the command line. See
 # "/usr/sbin/dnsmasq --help" or "man 8 dnsmasq" for details.
 
+# Listen on this specific port instead of the standard DNS port
+# (53). Setting this to zero completely disables DNS function,
+# leaving only DHCP and/or TFTP.
+#port=5353
+
 # Change these lines if you want dnsmasq to serve MX records.
 # Only one of mx-host and mx-target need be set, the other defaults
 # to the name of the host  running dnsmasq.
@@ -77,7 +82,7 @@ bogus-priv
 #except-interface=
 # Or which to listen on by address (remember to include 127.0.0.1 if
 # you use this.)
-#listen-address=
+#listen-address=127.0.0.1
 
 # On systems which support it, dnsmasq binds the wildcard address,
 # even when it is listening on only some interfaces. It then discards

--- a/meta-resin-common/recipes-connectivity/dnsmasq/files/dnsmasq.resolvconf
+++ b/meta-resin-common/recipes-connectivity/dnsmasq/files/dnsmasq.resolvconf
@@ -1,0 +1,84 @@
+#!/bin/sh
+#
+# Script to update the resolver list for dnsmasq
+#
+# N.B. Resolvconf may run us even if dnsmasq is not (yet) running.
+# If dnsmasq is installed then we go ahead and update the resolver list
+# in case dnsmasq is started later.
+#
+# Assumption: On entry, PWD contains the resolv.conf-type files.
+#
+# This file is part of the dnsmasq package.
+#
+
+set -e
+
+RUN_DIR="/run/dnsmasq"
+RSLVRLIST_FILE="${RUN_DIR}/resolv.conf"
+TMP_FILE="${RSLVRLIST_FILE}_new.$$"
+MY_NAME_FOR_RESOLVCONF="dnsmasq"
+
+[ -x /usr/bin/dnsmasq ] || exit 0
+[ -x /lib/resolvconf/list-records ] || exit 1
+
+PATH=/bin:/sbin
+
+report_err() { echo "$0: Error: $*" >&2 ; }
+
+# Stores arguments (minus duplicates) in RSLT, separated by spaces
+# Doesn't work properly if an argument itself contains whitespace
+uniquify()
+{
+	RSLT=""
+	while [ "$1" ] ; do
+		for E in $RSLT ; do
+			[ "$1" = "$E" ] && { shift ; continue 2 ; }
+		done
+		RSLT="${RSLT:+$RSLT }$1"
+		shift
+	done
+}
+
+if [ ! -d "$RUN_DIR" ] && ! mkdir --parents --mode=0755 "$RUN_DIR" ; then
+	report_err "Failed trying to create directory $RUN_DIR"
+	exit 1
+fi
+
+RSLVCNFFILES=""
+for F in $(/lib/resolvconf/list-records --after "lo.$MY_NAME_FOR_RESOLVCONF") ; do
+	case "$F" in
+	    "lo.$MY_NAME_FOR_RESOLVCONF")
+		# Omit own record
+		;;
+	    lo.*)
+		# Include no more records after one for a local nameserver
+		RSLVCNFFILES="${RSLVCNFFILES:+$RSLVCNFFILES }$F"
+		break
+		;;
+	  *)
+		RSLVCNFFILES="${RSLVCNFFILES:+$RSLVCNFFILES }$F"
+		;;
+	esac
+done
+
+NMSRVRS=""
+if [ "$RSLVCNFFILES" ] ; then
+	uniquify $(sed -n -e 's/^[[:space:]]*nameserver[[:space:]]\+//p' $RSLVCNFFILES)
+	NMSRVRS="$RSLT"
+fi
+
+# Dnsmasq uses the mtime of $RSLVRLIST_FILE, with a resolution of one second,
+# to detect changes in the file. This means that if a resolvconf update occurs
+# within one second of the previous one then dnsmasq may fail to notice the
+# more recent change. To work around this problem we sleep one second here
+# if necessary in order to ensure that the new mtime is different.
+if [ -f "$RSLVRLIST_FILE" ] && [ "$(stat -c %X "$RSLVRLIST_FILE")" = "$(date +%s)" ] ; then
+	sleep 1
+fi
+
+clean_up() { rm -f "$TMP_FILE" ; }
+trap clean_up EXIT
+: >| "$TMP_FILE"
+for N in $NMSRVRS ; do echo "nameserver $N" >> "$TMP_FILE" ; done
+mv -f "$TMP_FILE" "$RSLVRLIST_FILE"
+

--- a/meta-resin-common/recipes-connectivity/dnsmasq/files/init
+++ b/meta-resin-common/recipes-connectivity/dnsmasq/files/init
@@ -1,0 +1,117 @@
+#!/bin/sh
+DAEMON=/usr/bin/dnsmasq
+NAME=dnsmasq
+DESC="DNS forwarder and DHCP server"
+ARGS="-7 /etc/dnsmasq.d"
+
+test -f $DAEMON || exit 0
+
+set -e
+
+if [ -r /etc/default/$NAME ]
+then
+	. /etc/default/$NAME
+fi
+
+DNSMASQ_CONF="/etc/dnsmasq.conf"
+test "/etc/dnsmasq.d/*" != '/etc/dnsmasq.d/*' && DNSMASQ_CONF="${DNSMASQ_CONF} /etc/dnsmasq.d/*"
+
+test -z "${PIDFILE}" && PIFILE="/run/dnsmasq.pid"
+
+if [ -z "$IGNORE_RESOLVCONF" ]
+then
+	egrep -h -q '^no-resolv' ${DNSMASQ_CONF} && IGNORE_RESOLVCONF="yes"
+fi
+
+# RESOLV_CONF:
+# If the resolvconf package is installed then use the resolv conf file
+# that it provides as the default.  Otherwise use /etc/resolv.conf as
+# the default.
+#
+# If IGNORE_RESOLVCONF is set in /etc/default/dnsmasq or an explicit
+# filename is set there then this inhibits the use of the resolvconf-provided
+# information.
+#
+# Note that if the resolvconf package is installed it is not possible to
+# override it just by configuration in /etc/dnsmasq.conf, it is necessary
+# to set IGNORE_RESOLVCONF=yes in /etc/default/dnsmasq.
+
+test -z "$RESOLV_CONF" -a "$IGNORE_RESOLVCONF" != "yes" -a -x /sbin/resolvconf && \
+	RESOLV_CONF=/run/dnsmasq/resolv.conf
+
+start_resolvconf()
+{
+        if [ "$IGNORE_RESOLVCONF" != "yes" -a -x /sbin/resolvconf ]
+	then
+		echo "nameserver 127.0.0.1" | /sbin/resolvconf -a lo.$NAME
+	fi
+	:
+}
+
+stop_resolvconf()
+{
+	if [ "$IGNORE_RESOLVCONF" != "yes" -a -x /sbin/resolvconf ]
+	then
+		/sbin/resolvconf -d lo.$NAME
+	fi
+	:
+}
+
+case "$1" in
+    start)
+        echo -n "starting $DESC: $NAME... "
+	test -d /var/lib/misc/ || mkdir /var/lib/misc/
+	start-stop-daemon -S -x $DAEMON -- $ARGS \
+		${RESOLV_CONF:+ -r $RESOLV_CONF} \
+		${PIDFILE:+ -x $PIDFILE}
+	test $? -eq 0 && start_resolvconf
+	echo "done."
+	;;
+    stop)
+        echo -n "stopping $DESC: $NAME... "
+	stop_resolvconf
+	start-stop-daemon -K -x $DAEMON
+	echo "done."
+	;;
+    status)
+	echo -n "dnsmasq "
+	start-stop-daemon -q -K -t -x $DAEMON
+	RET=$?
+	if [ "$RET" = "0" ]; then
+		PID=`cat ${PIDFILE}`
+		echo "($PID) is running"
+	else
+		echo "is not running"
+		exit $RET
+	fi
+	;;
+    restart)
+        echo "restarting $DESC: $NAME... "
+ 	$0 stop
+	$0 start
+	echo "done."
+	;;
+    reload)
+    	echo -n "reloading $DESC: $NAME... "
+    	killall -HUP $(basename ${DAEMON})
+	echo "done."
+	;;
+    systemd-start-resolvconf)
+	start_resolvconf
+	;;
+    systemd-stop-resolvconf)
+	stop_resolvconf
+	;;
+    systemd-exec)
+	test -d /var/lib/misc/ || mkdir /var/lib/misc/
+	exec $DAEMON --keep-in-foreground $ARGS \
+		${RESOLV_CONF:+ -r $RESOLV_CONF} \
+		${PIDFILE:+ -x $PIDFILE}
+	;;
+    *)
+	echo "Usage: $0 {start|stop|status|restart|reload}"
+	exit 1
+	;;
+esac
+
+exit 0

--- a/meta-resin-common/recipes-connectivity/dnsmasq/files/lua.patch
+++ b/meta-resin-common/recipes-connectivity/dnsmasq/files/lua.patch
@@ -1,0 +1,26 @@
+From 1e5be0a0bcf85913d63408030dec038d360a5fa6 Mon Sep 17 00:00:00 2001
+From: Joe MacDonald <joe_macdonald@mentor.com>
+Date: Tue, 9 Sep 2014 10:24:58 -0400
+Subject: [PATCH] Upstream-status: Inappropriate [OE specific]
+
+Signed-off-by: Christopher Larson <chris_larson@mentor.com>
+
+---
+ Makefile |    4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 73ea23e..1dba188 100644
+--- a/Makefile
++++ b/Makefile
+@@ -59,8 +59,8 @@ idn2_cflags =   `echo $(COPTS) | $(top)/bld/pkg-wrapper HAVE_LIBIDN2 $(PKG_CONFI
+ idn2_libs =     `echo $(COPTS) | $(top)/bld/pkg-wrapper HAVE_LIBIDN2 $(PKG_CONFIG) --libs libidn2`
+ ct_cflags =     `echo $(COPTS) | $(top)/bld/pkg-wrapper HAVE_CONNTRACK $(PKG_CONFIG) --cflags libnetfilter_conntrack`
+ ct_libs =       `echo $(COPTS) | $(top)/bld/pkg-wrapper HAVE_CONNTRACK $(PKG_CONFIG) --libs libnetfilter_conntrack`
+-lua_cflags =    `echo $(COPTS) | $(top)/bld/pkg-wrapper HAVE_LUASCRIPT $(PKG_CONFIG) --cflags lua5.2` 
+-lua_libs =      `echo $(COPTS) | $(top)/bld/pkg-wrapper HAVE_LUASCRIPT $(PKG_CONFIG) --libs lua5.2` 
++lua_cflags =    `echo $(COPTS) | $(top)/bld/pkg-wrapper HAVE_LUASCRIPT $(PKG_CONFIG) --cflags lua` 
++lua_libs =      `echo $(COPTS) | $(top)/bld/pkg-wrapper HAVE_LUASCRIPT $(PKG_CONFIG) --libs lua` 
+ nettle_cflags = `echo $(COPTS) | $(top)/bld/pkg-wrapper HAVE_DNSSEC $(PKG_CONFIG) --cflags nettle hogweed`
+ nettle_libs =   `echo $(COPTS) | $(top)/bld/pkg-wrapper HAVE_DNSSEC $(PKG_CONFIG) --libs nettle hogweed`
+ gmp_libs =      `echo $(COPTS) | $(top)/bld/pkg-wrapper HAVE_DNSSEC NO_GMP --copy -lgmp`


### PR DESCRIPTION
This version includes several important security fixes.

Change-type: minor
Changelog-entry: Update dnsmasq to 2.78
Signed-off-by: Will Newton <willn@resin.io>