### PR TITLE
mkfs.hostapp-ext4: Make sure PATH contains entries to container's paths

### DIFF
--- a/meta-resin-common/recipes-containers/mkfs-hostapp-native/files/mkfs.hostapp-ext4
+++ b/meta-resin-common/recipes-containers/mkfs-hostapp-native/files/mkfs.hostapp-ext4
@@ -5,7 +5,8 @@ set -o errexit
 # We force the PATH to be the standard linux path in order to use the host's
 # docker daemon instead of the result of docker-native. This avoids version
 # mismatches
-DOCKER=$(PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" which docker)
+HOST_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+DOCKER=$(PATH="$HOST_PATH" which docker)
 
 sysroot="/"
 tmpdir=""
@@ -42,4 +43,4 @@ cleanup_docker() {
 $DOCKER load -i "$sysroot/usr/share/mkfs-hostapp-ext4-image.tar"
 trap cleanup_docker EXIT
 
-$DOCKER run --privileged --rm -v "$input:/input:ro" -v "$tmpdir:$tmpdir:ro" -v "$output:/output" -e "PATH=$PATH" @IMAGE@
+$DOCKER run --privileged --rm -v "$input:/input:ro" -v "$tmpdir:$tmpdir:ro" -v "$output:/output" -e "PATH=$PATH:$HOST_PATH" @IMAGE@


### PR DESCRIPTION
We use a yocto's PATH to pass it in the container for it to have access to the
sysroot paths. Since pyro, yocto has per recipe sysroots so a recipe will not
have access to a shared sysroot. In the same time, yocto's path excludes host
paths to avoid host contamination but pasing this path in the container will
make the container not able to find executables in the docker images based on
PATH. This patch makes sure that the PATH passed to the container contains
entries to host paths too.

Signed-off-by: Andrei Gherzan <andrei@resin.io>