### PR TITLE
docker-resin-supervisor-disk: allow supervisor start when no supervisor image present

### DIFF
--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/start-resin-supervisor
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/start-resin-supervisor
@@ -31,8 +31,13 @@ runSupervisor() {
         ${SUPERVISOR_IMAGE}:${SUPERVISOR_TAG}
 }
 
-if [ "$SUPERVISOR_IMAGE_ID" = "$SUPERVISOR_CONTAINER_IMAGE_ID" ]; then
+if [ -z "$SUPERVISOR_IMAGE_ID" ]; then
+    # No supervisor image exists on the device, try to pull it
+    systemctl start update-resin-supervisor
+elif [ "$SUPERVISOR_IMAGE_ID" = "$SUPERVISOR_CONTAINER_IMAGE_ID" ]; then
+    # Supervisor image exists, and the current supervisor container is created from
     docker start --attach resin_supervisor
 else
+    # No supervisor container exists or there's a different supervisor image to run
     runSupervisor
 fi


### PR DESCRIPTION
The previous logic did not take into account what happens if there is no resin-supervisor image nor container on the device, and could end up in a state that the device cannot automatically recover
itself from a missing supervisor image. This happened for example for resinHUP 1.x->2.x, when after the update it was necessary for the device to start up without any images or containers.

Add logic to handle the missing image case by running the update-resin-supervisor service when no image exists.

Also added comments so that the logic is documented.