### PR TITLE
housekeeping: adding PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+
+---
+### Contributor checklist
+<!-- For completed items, change [ ] to [x].  -->
+- [ ] Changes have been tested
+- [ ] `Change-type` present on at least one commit
+- [ ] `Signed-off-by` is present
+- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
+<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->
+
+### Reviewer Guidelines
+- When submitting a review, please pick:
+  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
+  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
+  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)


### PR DESCRIPTION
Creating a template, so that the requirements for good PRs can be codified, instead of the PR submitters warned after the PR was already submitted.
Adding items that I know of at the moment.