### PR TITLE
dosfstools: Add patch to fix fsck of boot partition

### DIFF
--- a/meta-resin-common/recipes-devtools/dosfstools/dosfstools/0001-src-check.c-Fix-up-mtools-created-bad-dir-entries.patch
+++ b/meta-resin-common/recipes-devtools/dosfstools/dosfstools/0001-src-check.c-Fix-up-mtools-created-bad-dir-entries.patch
@@ -1,0 +1,41 @@
+From 5cc3107689ba5234e1dafee3dcc276823aba7d80 Mon Sep 17 00:00:00 2001
+From: Will Newton <willn@resin.io>
+Date: Thu, 31 Aug 2017 10:42:13 +0100
+Subject: [PATCH] src/check.c: Fix up mtools created bad dir entries
+
+mtools writes uninitialized data to the case field of some
+directory entries. Running fsck.fat on these filesystems
+will cause the directory to get deleted which can lead to
+data loss. Detect this situation and clear the flag instead.
+
+mtools patch to fix the original issue:
+
+https://lists.gnu.org/archive/html/info-mtools/2014-08/msg00000.html
+
+Upstream-Status: Submitted
+Signed-off-by: Will Newton <willn@resin.io>
+---
+ src/check.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/check.c b/src/check.c
+index a2a752f..f1e18be 100644
+--- a/src/check.c
++++ b/src/check.c
+@@ -495,6 +495,13 @@ static int handle_dot(DOS_FS * fs, DOS_FILE * file, int dots)
+ 	    break;
+ 	}
+     }
++    if (file->dir_ent.lcase & FAT_NO_83NAME) {
++	/* Some versions of mtools write these directory entries with random data in
++	   this field. */
++	printf("%s\n  Is a dot with no 8.3 name flag set, clearing.\n", path_name(file));
++	file->dir_ent.lcase &= ~FAT_NO_83NAME;
++	MODIFY(file, lcase, file->dir_ent.lcase);
++    }
+     if (!dots) {
+ 	printf("Root contains directory \"%s\". Dropping it.\n", name);
+ 	drop_file(fs, file);
+-- 
+2.9.5
+

--- a/meta-resin-common/recipes-devtools/dosfstools/dosfstools_%.bbappend
+++ b/meta-resin-common/recipes-devtools/dosfstools/dosfstools_%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
+SRC_URI_append = " file://0001-src-check.c-Fix-up-mtools-created-bad-dir-entries.patch"


### PR DESCRIPTION
The boot partition contains some directory entries with bad flags
that were created by mtools. Fix fsck so it clears the flags rather
than destroying the system-connections directory.

Change-type: patch
Changelog-entry: Fix fsck of boot partition with dosfstools
Signed-off-by: Will Newton <willn@resin.io>