### PR TITLE
hostapp-update-hooks: Support grub

### DIFF
--- a/meta-resin-common/recipes-support/hostapp-update-hooks/files/99-resin-grub
+++ b/meta-resin-common/recipes-support/hostapp-update-hooks/files/99-resin-grub
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+#
+# Script which configures the grub.cfg to use an updated root index
+#
+
+set -o errexit
+
+new_part=$(findmnt --noheadings --canonicalize --output SOURCE "/mnt/sysroot/inactive")
+new_part_label=$(blkid "$new_part" | awk '{print $2}')
+
+printf "[INFO] Switching root partition to %s..." "$new_part_label..."
+sed "s/root=[^ ]* /"root=$new_part_label" /" /mnt/boot/EFI/BOOT/grub.cfg > /mnt/boot/EFI/BOOT/grub.cfg.new
+
+sync -f /mnt/boot/EFI/BOOT
+mv /mnt/boot/EFI/BOOT/grub.cfg.new /mnt/boot/EFI/BOOT/grub.cfg
+sync -f /mnt/boot/EFI/BOOT
+printf " done.\n"


### PR DESCRIPTION
A board specific layer should choose between 99-resin-grub
and 99-resin-uboot accordingly.

Change-type: patch
Changelog-entry: Support grub boards with hostapp-update-hooks
Signed-off-by: Theodor Gherzan <theodor@resin.io>