### PR TITLE
libqmi: Update to version 1.18.0

### DIFF
--- a/meta-resin-common/recipes-connectivity/libqmi/libqmi_1.18.0.bb
+++ b/meta-resin-common/recipes-connectivity/libqmi/libqmi_1.18.0.bb
@@ -14,5 +14,5 @@ inherit autotools pkgconfig bash-completion
 SRC_URI = "http://www.freedesktop.org/software/${BPN}/${BPN}-${PV}.tar.xz \
            file://0001-Detect-clang.patch \
            "
-SRC_URI[md5sum] = "4970c110f160b33637a3515004c637b2"
-SRC_URI[sha256sum] = "7ab6bb47fd23bf4d3fa17424e40ea5552d08b19e5ee4f125f21f316c8086ba2a"
+SRC_URI[md5sum] = "25bae4e383ad77f491ad49b49e04fdcf"
+SRC_URI[sha256sum] = "a0a42c55935e75a630208e2f70840bd4407f56fe1c5258f5b0f6c0aaedf88cec"


### PR DESCRIPTION
Change-type: patch
Changelog-entry: Update libqmi to version 1.18.0
Signed-off-by: Florin Sarbu <florin@resin.io>