### PR TITLE
kernel-resin.bbclass: Add required dependency for redsocks

### DIFF
--- a/meta-resin-common/classes/kernel-resin.bbclass
+++ b/meta-resin-common/classes/kernel-resin.bbclass
@@ -364,6 +364,7 @@ RESIN_CONFIGS[misc] = " \
 
 # configs needed for our usage of redsocks
 RESIN_CONFIGS[redsocks] = " \
+    CONFIG_NETFILTER_ADVANCED=y \
     CONFIG_NETFILTER_XT_MATCH_OWNER=m \
     CONFIG_NETFILTER_XT_TARGET_REDIRECT=m \
     "


### PR DESCRIPTION
The kernel option CONFIG_NETFILTER_XT_MATCH_OWNER also needs CONFIG_NETFILTER_ADVANCED

Change-type: patch
Changelog-entry: Add required kernel config dependency for being able to use redsocks
Signed-off-by: Florin Sarbu <florin@resin.io>