### PR TITLE
hostapp-update-hooks: Use boot files list from the 'next' OS

### DIFF
--- a/meta-resin-common/recipes-support/hostapp-update-hooks/files/0-bootfiles
+++ b/meta-resin-common/recipes-support/hostapp-update-hooks/files/0-bootfiles
@@ -98,6 +98,8 @@ if [ -z "$container_id" ]; then
 fi
 
 # Deploy all files in the bootfiles list
+bootfiles_list_new="/tmp/$(basename $bootfiles_list).new"
+docker cp "$container_id:$bootfiles_list" "$bootfiles_list_new"
 while read entry; do
 	deploy "$entry"
-done < "$bootfiles_list"
+done < "$bootfiles_list_new"


### PR DESCRIPTION
When copying boot files from the OS we update to, we were using the list of
files from the current OS. This is wrong because the version we update to might
come with new files or might have removed files.

Change-type: patch
Change-log-entry: When updating to a new host os use bootfiles list from the next OS
Signed-off-by: Andrei Gherzan <andrei@resin.io>