### PR TITLE
image-resin.bbclass: Add build time dependency on coreutils-native

### DIFF
--- a/meta-resin-common/classes/image-resin.bbclass
+++ b/meta-resin-common/classes/image-resin.bbclass
@@ -6,7 +6,7 @@ inherit image_types_resin
 
 # When building a Resin OS image, we also generate the kernel modules headers
 # and ship them in the deploy directory for out-of-tree kernel modules build
-DEPENDS += "kernel-modules-headers"
+DEPENDS += "coreutils-native kernel-modules-headers"
 
 # Deploy the license.manifest of the current image we baked
 deploy_image_license_manifest () {


### PR DESCRIPTION
We have a bunch of calls to the realtime binary in this class so let's also
depend on coreutils-native which provides this binary.

Change-type: patch
Change-log-entry: Add dependency to coreutils-native on build time
Signed-off-by: Florin Sarbu <florin@resin.io>