### PR TITLE
resin-device-register: Delete the provisioning key after registering,…

### DIFF
--- a/meta-resin-common/recipes-support/resin-device-register/resin-device-register/resin-device-register
+++ b/meta-resin-common/recipes-support/resin-device-register/resin-device-register/resin-device-register
@@ -64,7 +64,7 @@ while true; do
         if [ "$status_code" -eq 201 ]; then
             device_id=$(jq -r '.id' $LOG_FILE)
             config_json=$(cat "$CONFIG_PATH")
-            echo "$config_json" | jq -S ".registered_at=\"$(date +%s)\"|.deviceId=\"$device_id\"" > "$CONFIG_PATH"
+            echo "$config_json" | jq -S ".registered_at=\"$(date +%s)\"|.deviceId=\"$device_id\"|del(.apiKey)" > "$CONFIG_PATH"
             echo "[INFO] resin-device-register : Registered device with ID: $device_id and UUID: $UUID."
             exit 0
         else


### PR DESCRIPTION
… and write config.json atomically

This should prevent the VPN using the provisioning key to connect (which will not work). As soon as the device is provisioned, the deviceApiKey will be used for the VPN to connect.
This is better than changing prepare-openvpn to not use the provisioning key at all, cause in resinhup scenarios the deviceApiKey may not yet work, but in resin-device-register, which
only runs in the flasher, we're guaranteeing that the deviceApiKey has been registered.

This change also makes the write to config.json atomic by writing to a different file and then renaming it.

Change-Type: patch
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>