### PR TITLE
resin-init-flasher: Copy config.json to internal media

### DIFF
--- a/meta-resin-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-resin-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -169,8 +169,6 @@ fi
 # Copy custom splash dir
 mkdir -p "$INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT/$SPLASH_DIRNAME"
 cp -r $EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT/$SPLASH_DIRNAME/* $INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT/$SPLASH_DIRNAME
-# Copy json configuration file from external (flasher) to the internal (booting) device
-cp -rvf "$CONFIG_PATH" "$INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT"
 # Copy Network Manager connection files
 CONFIG_NM="${CONFIG_PATH%/*}/system-connections/"
 if [ -d "$CONFIG_NM" ]; then
@@ -202,8 +200,6 @@ if [ -f "${EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}/${RESIN_BOOTLOADER_CONFIG}" ]; 
         cp $EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT/$RESIN_BOOTLOADER_CONFIG $INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT
 fi
 
-umount $INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT
-
 inform "Board specific flash procedure..."
 /usr/bin/resin-init-flasher-board
 
@@ -221,6 +217,10 @@ do
         break
     fi
 done
+
+# Copy json configuration file from external (flasher) to the internal (booting) device
+cp -rvf "$CONFIG_PATH" "$INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT"
+umount $INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT
 
 sync
 


### PR DESCRIPTION
after giving resin-device-register a chance to run

We should do our best to ensure we copy the config.json from the flasher over
to the internal media after the resin-device-register script was executed and
hopefully registered the board.

Change-Type: patch
Changelog-entry: Do our best to ensure we copy to internal media the config.json after resin-device-register was able to register the board
Signed-off-by: Florin Sarbu <florin@resin.io>