### PR TITLE
resin-init-flasher.bb: Add runtime dependency on util-linux-lsblk

### DIFF
--- a/meta-resin-common/recipes-support/resin-init/resin-init-flasher.bb
+++ b/meta-resin-common/recipes-support/resin-init/resin-init-flasher.bb
@@ -25,6 +25,7 @@ RDEPENDS_${PN} = " \
     resin-init-board \
     parted \
     resin-init-flasher-board \
+    util-linux-lsblk \
     "
 
 # This should be just fine


### PR DESCRIPTION
Since commit 7a39577e0a36427e82efeab9a57b609f2c0e7c38
(resin-init-flasher: Detect the drive we are running from and ignore it)
we also need to have the flasher rootfs contain the lsblk binary.

Change-type: patch
Changelog-entry: Add the lsblk binary to the flasher rootfs
Signed-off-by: Florin Sarbu <florin@resin.io>