### PR TITLE
hostapp-update-hook: Fix 0-bootfiles when running hooks

### DIFF
--- a/meta-resin-common/recipes-support/hostapp-update-hooks/files/0-bootfiles
+++ b/meta-resin-common/recipes-support/hostapp-update-hooks/files/0-bootfiles
@@ -113,7 +113,7 @@ boot_space="$(df -B1 --output=avail $boot_mountpoint | grep -v Avail)"
 available="$boot_space"
 available_threshold="524288" # All sizes in bytes
 printf "[INFO] Checking if boot partition can accommodate the new update... "
-for filepath in $(find /resin-boot -type f | sed 's#/^resin-boot##g'); do
+for filepath in $(find /resin-boot -type f | sed 's#^/resin-boot##g'); do
 	if isBlacklisted "$filepath"; then
 		continue
 	fi
@@ -134,6 +134,6 @@ echo "success."
 
 # Deploy all files in the bootfiles list
 new_deployed_files=""
-for filepath in $(find /resin-boot -type f | sed 's#/^resin-boot##g'); do
+for filepath in $(find /resin-boot -type f | sed 's#^/resin-boot##g'); do
 	deploy "$filepath"
 done


### PR DESCRIPTION
Change-type: patch
Changelog-entry: Fix 0-bootfiles when running hooks
Signed-off-by: Andrei Gherzan <andrei@resin.io>