### PR TITLE
hostapp-update: Run the update container as privileged

### DIFF
--- a/meta-resin-common/recipes-containers/hostapp-update/files/hostapp-update
+++ b/meta-resin-common/recipes-containers/hostapp-update/files/hostapp-update
@@ -72,7 +72,7 @@ sync -f "$SYSROOT"
 
 if [ "$hooks" = 1 ]; then
 	# Run the defined hooks in the host OS we update to
-	if balena run --rm -v /mnt:/mnt -e DURING_UPDATE=1 "$HOSTAPP_IMAGE" hostapp-update-hooks; then
+	if balena run --privileged --rm -v /mnt:/mnt -e DURING_UPDATE=1 "$HOSTAPP_IMAGE" hostapp-update-hooks; then
 		echo "New hooks ran successfully."
 	else
 		# Something went wrong with the new hooks. Run the current ones to


### PR DESCRIPTION
Because as part of a host OS update we need to update the bootloader also,
for some boards we need to be able to write the bootloader directly to a
specific /dev entry. Hence we need the update container be able to have access
to /dev of the host.

Change-type: patch
Changelog-entry: Run the update container as privileged
Signed-off-by: Florin Sarbu <florin@resin.io>