### PR TITLE
balena: Update to version with healthcheck support

### DIFF
--- a/meta-resin-common/recipes-containers/balena/balena/balena.conf.systemd
+++ b/meta-resin-common/recipes-containers/balena/balena/balena.conf.systemd
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=/usr/bin/healthdog --healthcheck=/usr/lib/balena/balena-healthcheck /usr/bin/balenad --log-driver=journald -s @BALENA_STORAGE@ -H fd:// -H tcp://0.0.0.0:2375 --dns 10.114.102.1 --bip 10.114.101.1/24 --fixed-cidr=10.114.101.0/25
+ExecStart=/usr/bin/healthdog --healthcheck=/usr/lib/balena/balena-healthcheck /usr/bin/balenad --experimental --log-driver=journald -s @BALENA_STORAGE@ -H fd:// -H tcp://0.0.0.0:2375 --dns 10.114.102.1 --bip 10.114.101.1/24 --fixed-cidr=10.114.101.0/25

--- a/meta-resin-common/recipes-containers/balena/balena/balena.service
+++ b/meta-resin-common/recipes-containers/balena/balena/balena.service
@@ -9,7 +9,7 @@ Before=dnsmasq.service
 [Service]
 Type=notify
 Restart=always
-ExecStart=/usr/bin/healthdog --healthcheck=/usr/lib/balena/balena-healthcheck /usr/bin/balenad --log-driver=journald -s @BALENA_STORAGE@ -H fd:// --dns 10.114.102.1 --bip 10.114.101.1/24 --fixed-cidr=10.114.101.0/25
+ExecStart=/usr/bin/healthdog --healthcheck=/usr/lib/balena/balena-healthcheck /usr/bin/balenad --experimental --log-driver=journald -s @BALENA_STORAGE@ -H fd:// --dns 10.114.102.1 --bip 10.114.101.1/24 --fixed-cidr=10.114.101.0/25
 #Adjust OOMscore to -900 to make killing unlikely
 OOMScoreAdjust=-900
 MountFlags=slave

--- a/meta-resin-common/recipes-containers/balena/balena_git.bb
+++ b/meta-resin-common/recipes-containers/balena/balena_git.bb
@@ -10,7 +10,7 @@ pulling."
 inherit binary-compress
 FILES_COMPRESS = "/boot/init"
 
-SRCREV = "9c78e9b21021d2d2bbd17ebacc7ba9eacacc0742"
+SRCREV = "8d578b733f7d072c9d518392ff86347313501db5"
 SRCBRANCH = "17.06-resin"
 SRC_URI = "\
   git://github.com/resin-os/balena.git;branch=${SRCBRANCH};nobranch=1 \


### PR DESCRIPTION
As well run the daemon with experimental flag to enable restarting
unhealthy containers.

Change-type: minor
Changelog-entry: Update balena cu include healthcheck support
Signed-off-by: Andrei Gherzan <andrei@resin.io>