### PR TITLE
openvpn: In upscript.sh, change owner of the VPN status file to openv…

### DIFF
--- a/meta-resin-common/recipes-connectivity/openvpn/openvpn/upscript.sh
+++ b/meta-resin-common/recipes-connectivity/openvpn/openvpn/upscript.sh
@@ -2,3 +2,4 @@
 
 mkdir -p /run/openvpn/vpn_status
 touch /run/openvpn/vpn_status/active
+chown -R openvpn:openvpn /run/openvpn/vpn_status


### PR DESCRIPTION
…pn so that the downscript can delete it

Turns out openvpn runs the upscript as root, so the vpn_status/active file can't be deleted by the downscript when connectivity goes out,
because the latter is run as user openvpn.

(I would rather force the upscript to also run as user openvpn, but it seems that `su` doesn't work properly in resinOS?)

Changelog-entry: Fix openvpn reporting when connectivity goes out, due to a filesystem permissions issue
Change-Type: patch
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>