### PR TITLE
docker-resin-supervisor-disk: Don't manage supervisor with systemd

### DIFF
--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/resin-supervisor.service
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/resin-supervisor.service
@@ -16,11 +16,7 @@ After=\
     etc-resin\x2dsupervisor.mount
 
 [Service]
-Type=simple
-Restart=always
-RestartSec=10s
-EnvironmentFile=/etc/resin-supervisor/supervisor.conf
-EnvironmentFile=-/tmp/update-supervisor.conf
+Type=oneshot
 ExecStartPre=-@BINDIR@/balena stop resin_supervisor
 ExecStart=@BINDIR@/start-resin-supervisor
 ExecStop=-@BINDIR@/balena stop resin_supervisor

--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/start-resin-supervisor
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/start-resin-supervisor
@@ -2,13 +2,20 @@
 
 source /usr/sbin/resin-vars
 
+# The tmp supervisor.conf is used by the supervisor updater
+if [ -f /tmp/update-supervisor.conf ]; then
+    source /tmp/update-supervisor.conf
+else
+    source /etc/resin-supervisor/supervisor.conf
+fi
+
 SUPERVISOR_IMAGE_ID=$(balena inspect --format='{{.Id}}' $SUPERVISOR_IMAGE:$SUPERVISOR_TAG)
 SUPERVISOR_CONTAINER_IMAGE_ID=$(balena inspect --format='{{.Image}}' resin_supervisor || echo "")
 
 runSupervisor() {
     balena rm --force resin_supervisor || true
-    balena run --privileged --name resin_supervisor \
-        --net=host \
+    balena run -d --privileged --name resin_supervisor \
+        --net=host --restart=always \
         -v /var/run/balena.sock:/var/run/balena.sock \
         -v $CONFIG_PATH:/boot/config.json  \
         -v /mnt/data/apps.json:/boot/apps.json \
@@ -36,7 +43,7 @@ if [ -z "$SUPERVISOR_IMAGE_ID" ]; then
     systemctl start update-resin-supervisor
 elif [ "$SUPERVISOR_IMAGE_ID" = "$SUPERVISOR_CONTAINER_IMAGE_ID" ]; then
     # Supervisor image exists, and the current supervisor container is created from
-    balena start --attach resin_supervisor
+    balena start resin_supervisor
 else
     # No supervisor container exists or there's a different supervisor image to run
     runSupervisor

--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/update-resin-supervisor
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/update-resin-supervisor
@@ -70,7 +70,7 @@ fi
 function error_handler {
     # If docker pull fails, start the old supervisor again and exit
     rm -rf $UPDATECONF
-    systemctl start resin-supervisor
+    start-resin-supervisor
     exit 1
 }
 
@@ -135,7 +135,7 @@ fi
 
 # Try to stop old supervisor to prevent it deleting the intermediate images while downloading the new one
 echo "Stop supervisor..."
-systemctl stop resin-supervisor
+$DOCKER stop resin_supervisor || true
 
 # Pull target version.
 echo "Pulling supervisor $image_name:$tag..."
@@ -149,6 +149,6 @@ sed -e "s|SUPERVISOR_IMAGE=.*|SUPERVISOR_IMAGE=$image_name|" -e "s|SUPERVISOR_TA
 # Run supervisor with the device-type-specific options.
 # We give a specific name to the container to guarantee only one running.
 echo "Start supervisor..."
-systemctl start resin-supervisor
+start-resin-supervisor
 
 sed -i -e "s|SUPERVISOR_IMAGE=.*|SUPERVISOR_IMAGE=$image_name|" -e "s|SUPERVISOR_TAG=.*|SUPERVISOR_TAG=$tag|" /etc/resin-supervisor/supervisor.conf


### PR DESCRIPTION
With the work of healthcheck balena might restart supervisor in case of an
issue detected. This would mean that systemd will have to not trace the balena
run process. This needs changes in update-supervisor too as it will need to
manage the supervisor with balena and not with the systemd service.

Change-type: patch
Signed-off-by: Andrei Gherzan <andrei@resin.io>