### PR TITLE
docker-resin-supervisor-disk: Have the start-resin-supervisor script use

### DIFF
--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/start-resin-supervisor
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/start-resin-supervisor
@@ -16,7 +16,7 @@ runSupervisor() {
         -v /proc/net/fib_trie:/mnt/fib_trie \
         -v /var/log/supervisor-log:/var/log \
         -v /:/mnt/root \
-        -e DOCKER_ROOT=/mnt/root/var/lib/balena \
+        -e DOCKER_ROOT=/mnt/root/var/lib/docker \
         -e DOCKER_SOCKET=/var/run/balena.sock \
         -e BOOT_MOUNTPOINT=$BOOT_MOUNTPOINT \
         -e API_ENDPOINT=$API_ENDPOINT \


### PR DESCRIPTION
/mnt/root/var/lib/docker as DOCKER_ROOT until the supervisor handles this instead

Changelog-Entry: Pass /mnt/root/var/lib/docker as DOCKER_ROOT to the supervisor
Change-Type: patch
Signed-off-by: Florin Sarbu <florin@resin.io>