### PR TITLE
hostapp-update-hooks: Make 99-resin-grub also work with non-EFI grub …

### DIFF
--- a/meta-resin-common/recipes-support/hostapp-update-hooks/files/99-resin-grub
+++ b/meta-resin-common/recipes-support/hostapp-update-hooks/files/99-resin-grub
@@ -18,9 +18,10 @@ new_part=$(findmnt --noheadings --canonicalize --output SOURCE $SYSROOT)
 new_part_label=$(blkid "$new_part" | awk '{print $2}')
 
 printf "[INFO] Switching root partition to %s..." "$new_part_label..."
-sed "s/root=[^ ]* /"root=$new_part_label" /" /mnt/boot/EFI/BOOT/grub.cfg > /mnt/boot/EFI/BOOT/grub.cfg.new
+grub_cfg=$(find /mnt/boot/ -name grub.cfg)
+sed "s/root=[^ ]* /"root=$new_part_label" /" "$grub_cfg" > "$grub_cfg".new
 
-sync -f /mnt/boot/EFI/BOOT
-mv /mnt/boot/EFI/BOOT/grub.cfg.new /mnt/boot/EFI/BOOT/grub.cfg
-sync -f /mnt/boot/EFI/BOOT
+sync -f $(dirname "$grub_cfg")
+mv "$grub_cfg".new "$grub_cfg"
+sync -f $(dirname "$grub_cfg")
 printf " done.\n"


### PR DESCRIPTION
…configs

We need not search only for grub.cfg in EFI/BOOT directory as that location is not
used by non-EFI grub to place it's config in. Moreover, sometimes not all EFI grub
installations use this standard directory.

Change-type: patch
Changelog-entry: Make the grub hostapp update hook also work with non-EFI grub configs
Signed-off-by: Florin Sarbu <florin@resin.io>