### PR TITLE
kernel-resin.bbclass: Activate memory/swap cgroups

### DIFF
--- a/meta-resin-common/classes/kernel-resin.bbclass
+++ b/meta-resin-common/classes/kernel-resin.bbclass
@@ -138,6 +138,8 @@ RESIN_CONFIGS[balena] ?= " \
     CONFIG_EXT4_FS_POSIX_ACL=y \
     CONFIG_EXT4_FS_SECURITY=y \
     CONFIG_KEYS=y \
+    CONFIG_MEMCG=y \
+    CONFIG_MEMCG_SWAP=y \
     "
 
 RESIN_CONFIGS[aufs] = " \


### PR DESCRIPTION
With this, we can make sure balena is able to manage memory/swap limiting per
container.

Change-type: patch
Changelog-entry: Activate memory/swap cgroups in kernel
Signed-off-by: Andrei Gherzan <andrei@resin.io>