### PR TITLE
packagegroup-resin: Install resin-device-progress

### DIFF
--- a/meta-resin-common/recipes-core/packagegroups/packagegroup-resin.bb
+++ b/meta-resin-common/recipes-core/packagegroups/packagegroup-resin.bb
@@ -22,6 +22,7 @@ RDEPENDS_${PN} += " \
     resin-info \
     resin-hostname \
     resin-state-reset \
+    resin-device-progress \
     ${@bb.utils.contains('BALENA_STORAGE', 'aufs', 'aufs-util', '', d)} \
     ${@bb.utils.contains('RESIN_CONNECTABLE', '1', 'resin-connectable', '', d)} \
     ${@bb.utils.contains('RESIN_CONNECTABLE', '1', 'resin-provisioner', '', d)} \


### PR DESCRIPTION
This script is a dependency of resinOS updates. It was removed by mistake
when you dropped resinhup dummy script from resin-image. It used to be a
dependency of the removed package. Without this dependency this tool was
removed from the image.

Change-type: patch
Changelog-entry: Bring back resin-device-progress in resin-image
Signed-off-by: Andrei Gherzan <andrei@resin.io>