### PR TITLE
systemd: Backport patch to fix Remote DOS of systemd-resolve service

### DIFF
--- a/meta-resin-common/recipes-core/systemd/systemd/0001-resolved-fix-loop-on-packets-with-pseudo-dns-types-229.patch
+++ b/meta-resin-common/recipes-core/systemd/systemd/0001-resolved-fix-loop-on-packets-with-pseudo-dns-types-229.patch
@@ -1,0 +1,45 @@
+From 9f939335a07085aa9a9663efd1dca06ef6405d62 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zbigniew=20J=C4=99drzejewski-Szmek?= <zbyszek@in.waw.pl>
+Date: Wed, 25 Oct 2017 11:19:19 +0200
+Subject: [PATCH] resolved: fix loop on packets with pseudo dns types
+
+Reported by Karim Hossen & Thomas Imbert from Sogeti ESEC R&D.
+
+https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1725351
+
+Patch rebased for systemd on versions <= 229.
+
+Upstream-Status: Backport
+Signed-off-by: Andrei Gherzan <andrei@resin.io>
+
+---
+ src/resolve/resolved-dns-packet.c | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/src/resolve/resolved-dns-packet.c b/src/resolve/resolved-dns-packet.c
+index e2f227b..35f4d06 100644
+--- a/src/resolve/resolved-dns-packet.c
++++ b/src/resolve/resolved-dns-packet.c
+@@ -1514,7 +1514,7 @@ static int dns_packet_read_type_window(DnsPacket *p, Bitmap **types, size_t *sta
+
+                 found = true;
+
+-                while (bitmask) {
++                for (; bitmask; bit++, bitmask >>= 1)
+                         if (bitmap[i] & bitmask) {
+                                 uint16_t n;
+
+@@ -1528,10 +1528,6 @@ static int dns_packet_read_type_window(DnsPacket *p, Bitmap **types, size_t *sta
+                                 if (r < 0)
+                                         goto fail;
+                         }
+-
+-                        bit ++;
+-                        bitmask >>= 1;
+-                }
+         }
+
+         if (!found)
+--
+2.7.4
+

--- a/meta-resin-common/recipes-core/systemd/systemd/0001-resolved-fix-loop-on-packets-with-pseudo-dns-types.patch
+++ b/meta-resin-common/recipes-core/systemd/systemd/0001-resolved-fix-loop-on-packets-with-pseudo-dns-types.patch
@@ -1,0 +1,43 @@
+From 9f939335a07085aa9a9663efd1dca06ef6405d62 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zbigniew=20J=C4=99drzejewski-Szmek?= <zbyszek@in.waw.pl>
+Date: Wed, 25 Oct 2017 11:19:19 +0200
+Subject: [PATCH] resolved: fix loop on packets with pseudo dns types
+
+Reported by Karim Hossen & Thomas Imbert from Sogeti ESEC R&D.
+
+https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1725351
+
+Upstream-Status: Backport
+Signed-off-by: Andrei Gherzan <andrei@resin.io>
+
+---
+ src/resolve/resolved-dns-packet.c | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/src/resolve/resolved-dns-packet.c b/src/resolve/resolved-dns-packet.c
+index e2f227b..35f4d06 100644
+--- a/src/resolve/resolved-dns-packet.c
++++ b/src/resolve/resolved-dns-packet.c
+@@ -1514,7 +1514,7 @@ static int dns_packet_read_type_window(DnsPacket *p, Bitmap **types, size_t *sta
+
+                 found = true;
+
+-                while (bitmask) {
++                for (; bitmask; bit++, bitmask >>= 1)
+                         if (bitmap[i] & bitmask) {
+                                 uint16_t n;
+
+@@ -1528,10 +1528,6 @@ static int dns_packet_read_type_window(DnsPacket *p, Bitmap **types, size_t *sta
+                                 if (r < 0)
+                                         return r;
+                         }
+-
+-                        bit++;
+-                        bitmask >>= 1;
+-                }
+         }
+
+         if (!found)
+--
+2.7.4
+

--- a/meta-resin-common/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-resin-common/recipes-core/systemd/systemd_%.bbappend
@@ -10,6 +10,23 @@ SRC_URI_append = " \
     file://resin_update_state_probe \
     "
 
+python() {
+	import re
+
+	pv = d.getVar('PV', True)
+	srcuri = d.getVar('SRC_URI', True)
+
+	# Versions before 236 are affected by CVE-2017-15908
+	# https://nvd.nist.gov/vuln/detail/CVE-2017-15908
+	# Backport the relevant patch on the affected versions
+	m = re.search('([0-9]*)\+*(.*)',pv)
+	systemd_version = int(m.group(1))
+	if systemd_version <= 229:
+		d.setVar('SRC_URI', srcuri + ' file://0001-resolved-fix-loop-on-packets-with-pseudo-dns-types-229.patch')
+	elif systemd_version < 236:
+		d.setVar('SRC_URI', srcuri + ' file://0001-resolved-fix-loop-on-packets-with-pseudo-dns-types.patch')
+}
+
 FILES_${PN} += " \
     /srv \
     /etc/localtime \


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Andrei Gherzan <andrei@resin.io>

Fixes: https://github.com/resin-os/meta-resin/issues/916