### PR TITLE
hostapp-update: Bind mount /dev from host so we can resolv labels

### DIFF
--- a/meta-resin-common/recipes-containers/hostapp-update/files/hostapp-update
+++ b/meta-resin-common/recipes-containers/hostapp-update/files/hostapp-update
@@ -74,7 +74,7 @@ sync -f "$SYSROOT"
 
 if [ "$hooks" = 1 ]; then
 	# Run the defined hooks in the host OS we update to
-	if balena run --privileged --rm -v /mnt:/mnt -e DURING_UPDATE=1 "$HOSTAPP_IMAGE" hostapp-update-hooks; then
+	if balena run --privileged --rm -v /dev:/dev -v /mnt:/mnt -e DURING_UPDATE=1 "$HOSTAPP_IMAGE" hostapp-update-hooks; then
 		echo "New hooks ran successfully."
 	else
 		# Something went wrong with the new hooks.


### PR DESCRIPTION
Some hooks use blkid which needs to be able to resolve labels for the mounts
on fs labels. In order to make this tool work in the container we bind mount
/dev which will make fs labels resolve to the block devices.

Change-type: patch
Signed-off-by: Andrei Gherzan <andrei@resin.io>