### PR TITLE
NetworkManager: Allow managing "non-balena" bridge interfaces

### DIFF
--- a/meta-resin-common/recipes-connectivity/networkmanager/files/NetworkManager.conf
+++ b/meta-resin-common/recipes-connectivity/networkmanager/files/NetworkManager.conf
@@ -4,4 +4,4 @@ plugins=keyfile
 autoconnect-retries-default=0
 
 [keyfile]
-unmanaged-devices=type:bridge;type:tun;type:veth
+unmanaged-devices=interface-name:balena*;interface-name:br*;type:tun;type:veth


### PR DESCRIPTION
Let network manager manage bridge devices that are not managed by balena. In
this way users will be able to create bridge interface through network manager.

Change-type: patch
Signed-off-by: Andrei Gherzan <andrei@resin.io>
  