### PR TITLE
coreutils: Set uptime to use procfs for accurate uptime

### DIFF
--- a/meta-resin-common/recipes-core/coreutils/coreutils_%.bbappend
+++ b/meta-resin-common/recipes-core/coreutils/coreutils_%.bbappend
@@ -1,0 +1,1 @@
+CFLAGS_append_class-target = " -DHAVE_PROC_UPTIME"


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Andrei Gherzan <andrei@resin.io>