### PR TITLE
mkfs-hostapp-native: Use BALENA_STORAGE even if it's machine specific

### DIFF
--- a/meta-resin-common/recipes-containers/mkfs-hostapp-native/mkfs-hostapp-native.bb
+++ b/meta-resin-common/recipes-containers/mkfs-hostapp-native/mkfs-hostapp-native.bb
@@ -16,6 +16,15 @@ DEPENDS = " \
     e2fsprogs-native \
     "
 
+python __anonymous() {
+	# Force BALENA_STORAGE to use the machine specific definition even if we
+	# are building a native recipe
+	machine = d.getVar("MACHINE", True)
+	bs_machine = d.getVar("BALENA_STORAGE_" + machine, True)
+	if bs_machine:
+		d.setVar("BALENA_STORAGE", bs_machine)
+}
+
 S = "${WORKDIR}"
 
 do_compile () {


### PR DESCRIPTION
When using machine specific variables the parser will consider it only
available target recipes. This change forces this native recipe to use the
definition of BALENA_STORAGE when a machine specific definition is available.

Change-type: patch
Changelog-entry: Fix BALENA_STORAGE when machine specific definition is used
Signed-off-by: Andrei Gherzan <andrei@resin.io>