### PR TITLE
kernel-modules-headers: Compile depends on do_patch

### DIFF
--- a/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
+++ b/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
@@ -34,7 +34,7 @@ do_deploy() {
     cp kernel_modules_headers.tar.gz ${DEPLOYDIR}
 }
 
-do_compile[depends] += "virtual/kernel:do_deploy"
+do_compile[depends] += "virtual/kernel:do_deploy virtual/kernel:do_patch"
 addtask deploy before do_package after do_install
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
When compiling this package, the tool uses the kernel source directory
STAGING_KERNEL_DIR along with the deploy dir (which includes artifacts from
building the kernel). We already depend on do_deploy for kernel but when building
from sstate, the STAGING_KERNEL_DIR is not populated. Make sure that is
populated when compiling kernel-modules-headers by adding an explicit
dependency to kernel:do_patch.

Change-type: patch
Changelog-entry: Fix kernel-modules-headers when building from sstate
Signed-off-by: Andrei Gherzan <andrei@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
