### PR TITLE
openvpn: Let systemd handle the run directory

### DIFF
--- a/meta-resin-common/recipes-connectivity/openvpn/openvpn/openvpn-resin.service
+++ b/meta-resin-common/recipes-connectivity/openvpn/openvpn/openvpn-resin.service
@@ -11,7 +11,6 @@ RestartSec=10s
 #Adjust OOMscore to -1000 to disable OOM killing for openvpn
 OOMScoreAdjust=-1000
 PIDFile=/var/run/openvpn/resin.pid
-ExecStartPre=-/bin/mkdir -p /var/run/openvpn
 ExecStart=/usr/sbin/openvpn --daemon --writepid /var/run/openvpn/resin.pid --cd /etc/openvpn/ --config /run/openvpn/resin.conf
 
 [Install]


### PR DESCRIPTION
Openvpn already deploys a tmpfiles configuration for systemd to handle the run directory. No need for this service StartPre anymore.
    
Fixes #167
    
Change-type: patch
Changelog-entry: Let systemd handle openvpn run directory
Signed-off-by: Andrei Gherzan <andrei@resin.io>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
