### PR TITLE
dropbear_%.bbappend: conditionally apply backported patch

### DIFF
--- a/meta-resin-common/recipes-core/dropbear/dropbear_%.bbappend
+++ b/meta-resin-common/recipes-core/dropbear/dropbear_%.bbappend
@@ -6,14 +6,15 @@ SRC_URI += " \
     file://dropbearkey.conf \
     "
 
-# starting with dropbear version 2016.73, code indentation has been fixed thus making our current patch (use_atomic_key_generation_in_all_cases.patch) not work anymore
+# In dropbear versions 2016.73 and 2016.74 the code indentation has been fixed thus making our current patch (use_atomic_key_generation_in_all_cases.patch) not work anymore
 # we work around this by detecting the dropbear version and applying the right patch for it
+# Also, starting with dropbear version 2017.75 this patch is included so no need to apply it for the 2017.75 version or newer ones
 python() {
     packageVersion = d.getVar('PV', True)
     srcURI = d.getVar('SRC_URI', True)
-    if packageVersion >= '2016.73':
+    if packageVersion >= '2016.73' and packageVersion <= '2016.74':
         d.setVar('SRC_URI', srcURI + ' ' + 'file://use_atomic_key_generation_in_all_cases_reworked.patch')
-    else:
+    elif packageVersion < '2016.73':
         d.setVar('SRC_URI', srcURI + ' ' + 'file://use_atomic_key_generation_in_all_cases.patch')
 }
 


### PR DESCRIPTION
use_atomic_key_generation_in_all_cases for version
2017.75 or newer.

Starting with dropbear version 2017.75 this patch is included
so no need to apply this backported patch to these dropbear versions.

Change-type: patch
Changelog-entry: Do not apply the use_atomic_key_generation_in_all_cases patch for dropbear 2017.75 or newer
Signed-off-by: Florin Sarbu <florin@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
