### PR TITLE
modemmanager_1.7.990.bb: Add dependency to libxslt-native

### DIFF
--- a/meta-resin-common/recipes-connectivity/modemmanager/modemmanager_1.7.990.bb
+++ b/meta-resin-common/recipes-connectivity/modemmanager/modemmanager_1.7.990.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = " \
 
 inherit gnomebase gettext systemd vala bash-completion
 
-DEPENDS = "glib-2.0 libgudev dbus-glib intltool-native"
+DEPENDS = "glib-2.0 libgudev dbus-glib intltool-native libxslt-native"
 
 SRC_URI = "http://www.freedesktop.org/software/ModemManager/ModemManager-${PV}.tar.xz \
 "


### PR DESCRIPTION
When compiling with Poky Rocko we need to explictily add a build-time
dependency to libxslt-native.

Change-type: patch
Changelog-entry: Make ModemManager depend on libxslt-native at build-time for Poky Rocko
Signed-off-by: Florin Sarbu <florin@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
