### PR TITLE
resin-provisioner_1.0.4.bbappend: Fix compile issue on Poky Rocko

### DIFF
--- a/meta-resin-rocko/recipes-go/resin-provisioner/resin-provisioner_1.0.4.bbappend
+++ b/meta-resin-rocko/recipes-go/resin-provisioner/resin-provisioner_1.0.4.bbappend
@@ -1,0 +1,4 @@
+do_compile() {
+    export CGO_ENABLED=1
+    go_do_compile
+}


### PR DESCRIPTION
This commit fixes the following error when using Poky Rocko:

| build/tmp/work/core2-64-poky-linux/resin-provisioner/1.0.4-r0/go-tmp/go-link-534922009/go.o:(.data.rel.ro+0x403700): undefined reference to `main.init'
| build/tmp/work/core2-64-poky-linux/resin-provisioner/1.0.4-r0/go-tmp/go-link-534922009/go.o:(.data.rel.ro+0x403708): undefined reference to `main.main'

Change-type: patch
Changelog-entry: Fix resin-provisioner 1.0.4 compile error on Poky Rocko
Signed-off-by: Florin Sarbu <florin@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
