### PR TITLE
resin-image-flasher.bb: Replace deprecated variable IMAGE_DEPENDS

### DIFF
--- a/meta-resin-common/recipes-core/images/resin-image-flasher.bb
+++ b/meta-resin-common/recipes-core/images/resin-image-flasher.bb
@@ -14,7 +14,7 @@ IMAGE_FSTYPES = ""
 RESIN_ROOT_FSTYPE = "ext4"
 
 # Make sure you have the resin image ready
-IMAGE_DEPENDS_resinos-img_append = " resin-image:do_rootfs"
+do_image_resinos_img[depends] += "resin-image:do_rootfs"
 
 IMAGE_FEATURES_append = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'development-image', 'debug-tweaks', '', d)} \


### PR DESCRIPTION
Poky Rocko has deprecated the IMAGE_DEPENDS variable.

This commit fixes the following bitbake error:

resin-image-flasher.bb: Deprecated variable(s) found: "IMAGE_DEPENDS_resinos-img". Use do_image_<type>[depends] += "<recipe>:<task>" instead

Change-type: patch
Changelog-entry: Replace deprecated variable IMAGE_DEPENDS from resin-image-flasher.bb
Signed-off-by: Florin Sarbu <florin@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
