### PR TITLE
image_types_resin.bbclass: Replace deprecated variable IMAGE_DEPENDS

### DIFF
--- a/meta-resin-common/classes/image_types_resin.bbclass
+++ b/meta-resin-common/classes/image_types_resin.bbclass
@@ -78,6 +78,8 @@ python() {
         d.setVar('RESIN_RAW_IMG', '${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.resinos-img')
         d.setVar('RESIN_DOCKER_IMG', '${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.docker')
         d.setVar('RESIN_HOSTAPP_IMG', '${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.hostapp-ext4')
+
+    d.setVar('RESIN_IMAGE_BOOTLOADER_DEPLOY_TASK', ' '.join(bootloader + ':do_populate_sysroot' for bootloader in d.getVar("RESIN_IMAGE_BOOTLOADER", True).split()))
 }
 
 
@@ -107,15 +109,15 @@ RESIN_STATE_FS ?= "${WORKDIR}/${RESIN_STATE_FS_LABEL}.img"
 
 # resinos-img depends on the rootfs image
 IMAGE_TYPEDEP_resinos-img = "${RESIN_ROOT_FSTYPE}"
-IMAGE_DEPENDS_resinos-img = " \
-    coreutils-native \
-    docker-disk \
-    dosfstools-native \
-    e2fsprogs-native \
-    mtools-native \
-    parted-native \
-    virtual/kernel \
-    ${RESIN_IMAGE_BOOTLOADER} \
+do_image_resinos_img[depends] = " \
+    coreutils-native:do_populate_sysroot \
+    docker-disk:do_deploy \
+    dosfstools-native:do_populate_sysroot \
+    e2fsprogs-native:do_populate_sysroot \
+    mtools-native:do_populate_sysroot \
+    parted-native:do_populate_sysroot \
+    virtual/kernel:do_deploy \
+    ${RESIN_IMAGE_BOOTLOADER_DEPLOY_TASK} \
     "
 
 device_specific_configuration() {
@@ -342,8 +344,8 @@ IMAGE_CMD_docker () {
 
 IMAGE_TYPEDEP_hostapp-ext4 = "docker"
 
-IMAGE_DEPENDS_hostapp-ext4 = " \
-    mkfs-hostapp-native \
+do_image_hostapp_ext4[depends] = " \
+    mkfs-hostapp-native:do_populate_sysroot \
     "
 
 IMAGE_CMD_hostapp-ext4 () {


### PR DESCRIPTION
Poky Rocko has deprecated the IMAGE_DEPENDS variable.

Added dependencies to do_deploy tasks for target packages and do_populate_sysroot for native packages.

This commit fixes the following bitbake errors:

resin-image.bb: Deprecated variable(s) found: "IMAGE_DEPENDS_resinos-img, IMAGE_DEPENDS_hostapp-ext4". Use do_image_<type>[depends] += "<recipe>:<task>" instead
resin-image-flasher.bb: Deprecated variable(s) found: "IMAGE_DEPENDS_resinos-img". Use do_image_<type>[depends] += "<recipe>:<task>" instead

Also, some boards may define multiple bootloaders. An example:
https://github.com/resin-os/resin-intel/blob/master/layers/meta-resin-genericx86/recipes-core/images/resin-image.inc#L12

Given the above fact, we also needed to process this bootloader list and append to appropeiate do_deploy task to eash bootloader found in the list.

Change-type: patch
Changelog-entry: Replace deprecated variable IMAGE_DEPENDS from image_types_resin.bbclass
Signed-off-by: Florin Sarbu <florin@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
