### PR TITLE
openvpn: Update to 2.4.3

### DIFF
--- a/meta-resin-common/recipes-connectivity/openvpn/openvpn/openvpn
+++ b/meta-resin-common/recipes-connectivity/openvpn/openvpn/openvpn
@@ -1,0 +1,104 @@
+#!/bin/sh -e
+#
+# Original version by Robert Leslie
+# <rob@mars.org>, edited by iwj and cs
+# Modified for openvpn by Alberto Gonzalez Iniesta <agi@agi.as>
+# Modified for restarting / starting / stopping single tunnels by Richard Mueller <mueller@teamix.net>
+
+test $DEBIAN_SCRIPT_DEBUG && set -v -x
+
+DAEMON=/usr/sbin/openvpn
+CONFIG_DIR=/etc/openvpn
+test -x $DAEMON || exit 0
+test -d $CONFIG_DIR || exit 0
+
+start_vpn () {
+    modprobe tun >/dev/null 2>&1 || true
+    $DAEMON --daemon --writepid /var/run/openvpn.$NAME.pid \
+            --config $CONFIG_DIR/$NAME.conf --cd $CONFIG_DIR || echo -n " FAILED->"
+    echo -n " $NAME"
+}
+stop_vpn () {
+   kill `cat $PIDFILE` || true
+  rm $PIDFILE
+}
+
+case "$1" in
+start)
+  echo -n "Starting openvpn:"
+
+  if test -z $2 ; then
+    for CONFIG in `cd $CONFIG_DIR; ls *.conf 2> /dev/null`; do
+      NAME=${CONFIG%%.conf}
+      start_vpn
+    done
+  else
+    if test -e $CONFIG_DIR/$2.conf ; then
+      NAME=$2
+      start_vpn
+    else
+      echo -n " No such VPN: $2"
+    fi
+  fi
+  echo "."
+
+  ;;
+stop)
+  echo -n "Stopping openvpn:"
+
+  if test -z $2 ; then
+    for PIDFILE in `ls /var/run/openvpn.*.pid 2> /dev/null`; do
+      NAME=`echo $PIDFILE | cut -c18-`
+      NAME=${NAME%%.pid}
+      stop_vpn
+      echo -n " $NAME"
+    done
+  else
+    if test -e /var/run/openvpn.$2.pid ; then
+      PIDFILE=`ls /var/run/openvpn.$2.pid 2> /dev/null`
+      NAME=`echo $PIDFILE | cut -c18-`
+      NAME=${NAME%%.pid}
+      stop_vpn
+      echo -n " $NAME"
+    else
+      echo -n " No such VPN: $2"
+    fi
+  fi
+  echo "."
+  ;;
+# We only 'reload' for running VPNs. New ones will only start with 'start' or 'restart'.
+reload|force-reload)
+  echo -n "Reloading openvpn:"
+  for PIDFILE in `ls /var/run/openvpn.*.pid 2> /dev/null`; do
+    NAME=`echo $PIDFILE | cut -c18-`
+    NAME=${NAME%%.pid}
+# If openvpn if running under a different user than root we'll need to restart
+    if egrep '^( |\t)*user' $CONFIG_DIR/$NAME.conf > /dev/null 2>&1 ; then
+      stop_vpn
+      sleep 1
+      start_vpn
+      echo -n "(restarted)"
+    else
+      kill -HUP `cat $PIDFILE` || true
+#    start-stop-daemon --stop --signal HUP --quiet --oknodo \
+#      --exec $DAEMON --pidfile $PIDFILE
+    echo -n " $NAME"
+    fi
+  done
+  echo "."
+  ;;
+
+restart)
+  $0 stop $2
+  sleep 1
+  $0 start $2
+  ;;
+*)
+  echo "Usage: $0 {start|stop|reload|restart|force-reload}" >&2
+  exit 1
+  ;;
+esac
+
+exit 0
+
+# vim:set ai et sts=2 sw=2 tw=0:

--- a/meta-resin-common/recipes-connectivity/openvpn/openvpn/openvpn-volatile.conf
+++ b/meta-resin-common/recipes-connectivity/openvpn/openvpn/openvpn-volatile.conf
@@ -1,0 +1,1 @@
+d @LOCALSTATEDIR@/run/openvpn 0755 root root -

--- a/meta-resin-common/recipes-connectivity/openvpn/openvpn/openvpn@.service
+++ b/meta-resin-common/recipes-connectivity/openvpn/openvpn/openvpn@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=OpenVPN Robust And Highly Flexible Tunneling Application On %I
+After=syslog.target network.target
+
+[Service]
+PrivateTmp=true
+Type=forking
+PIDFile=/var/run/openvpn/%i.pid
+ExecStart=/usr/sbin/openvpn --daemon --writepid /var/run/openvpn/%i.pid --cd /etc/openvpn/ --config %i.conf
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-resin-common/recipes-connectivity/openvpn/openvpn_2.4.3.bb
+++ b/meta-resin-common/recipes-connectivity/openvpn/openvpn_2.4.3.bb
@@ -1,0 +1,67 @@
+SUMMARY = "A full-featured SSL VPN solution via tun device."
+HOMEPAGE = "http://openvpn.sourceforge.net"
+SECTION = "net"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=e9b64491ec98eb6c6493ac5e4118f107"
+DEPENDS = "lzo openssl iproute2 ${@bb.utils.contains('DISTRO_FEATURES', 'pam', 'libpam', '', d)}"
+
+inherit autotools systemd
+
+SRC_URI = "http://swupdate.openvpn.org/community/releases/${BP}.tar.gz \
+           file://openvpn \
+           file://openvpn@.service \
+           file://openvpn-volatile.conf"
+
+SRC_URI[md5sum] = "e1929f82aff40f3d105e5f72aacff9c1"
+SRC_URI[sha256sum] = "cee3d3ca462960a50a67c0ebd186e01b6d13db70275205663695152c9aca8579"
+
+SYSTEMD_SERVICE_${PN} += "openvpn@loopback-server.service openvpn@loopback-client.service"
+SYSTEMD_AUTO_ENABLE = "disable"
+
+CFLAGS += "-fno-inline"
+
+# I want openvpn to be able to read password from file (hrw)
+EXTRA_OECONF += "--enable-iproute2"
+EXTRA_OECONF += "${@bb.utils.contains('DISTRO_FEATURES', 'pam', '', '--disable-plugin-auth-pam', d)}"
+
+# Explicitly specify IPROUTE to bypass the configure-time check for /sbin/ip on the host.
+EXTRA_OECONF += "IPROUTE=${base_sbindir}/ip"
+
+do_install_append() {
+    install -d ${D}/${sysconfdir}/init.d
+    install -m 755 ${WORKDIR}/openvpn ${D}/${sysconfdir}/init.d
+
+    install -d ${D}/${sysconfdir}/openvpn
+    install -d ${D}/${sysconfdir}/openvpn/sample
+    install -m 755 ${S}/sample/sample-config-files/loopback-server  ${D}${sysconfdir}/openvpn/sample/loopback-server.conf
+    install -m 755 ${S}/sample/sample-config-files/loopback-client  ${D}${sysconfdir}/openvpn/sample/loopback-client.conf
+    install -dm 755 ${D}${sysconfdir}/openvpn/sample/sample-keys
+    install -m 644 ${S}/sample/sample-keys/* ${D}${sysconfdir}/openvpn/sample/sample-keys
+
+    if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+        install -d ${D}/${systemd_unitdir}/system
+        install -m 644 ${WORKDIR}/openvpn@.service ${D}/${systemd_unitdir}/system
+        install -m 644 ${WORKDIR}/openvpn@.service ${D}/${systemd_unitdir}/system/openvpn@loopback-server.service
+        install -m 644 ${WORKDIR}/openvpn@.service ${D}/${systemd_unitdir}/system/openvpn@loopback-client.service
+
+        install -d ${D}/${localstatedir}
+        install -d ${D}/${localstatedir}/lib
+        install -d -m 710 ${D}/${localstatedir}/lib/openvpn
+
+        install -d ${D}${sysconfdir}/tmpfiles.d
+        install -m 0644 ${WORKDIR}/openvpn-volatile.conf ${D}${sysconfdir}/tmpfiles.d/openvpn.conf
+        sed -i -e 's#@LOCALSTATEDIR@#${localstatedir}#g' ${D}${sysconfdir}/tmpfiles.d/openvpn.conf
+    fi
+}
+
+PACKAGES =+ " ${PN}-sample "
+
+RRECOMMENDS_${PN} = "kernel-module-tun"
+
+FILES_${PN}-dbg += "${libdir}/openvpn/plugins/.debug"
+FILES_${PN} += "${systemd_unitdir}/system/openvpn@.service \
+                ${sysconfdir}/tmpfiles.d \
+               "
+FILES_${PN}-sample += "${systemd_unitdir}/system/openvpn@loopback-server.service \
+                       ${systemd_unitdir}/system/openvpn@loopback-client.service \
+                       ${sysconfdir}/openvpn/sample/"


### PR DESCRIPTION
Connected to https://github.com/resin-os/meta-resin/issues/997

This recipe is imported from meta-oe/rocko.

ResinOS needs dualstack support which is included from openvpn 2.4. We add this
recipe in the common meta-resin layer to make sure that all of our supported
boards have this available.

Change-type: patch
Changelog-entry: Update OpenVPN to 2.4.3
Signed-off-by: Andrei Gherzan <andrei@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
