### PR TITLE
systemd: Add a temporary console fix until moby fixes it

### DIFF
--- a/meta-resin-pyro/recipes-core/systemd/systemd/0001-core-Don-t-redirect-stdio-to-null-when-running-in-co.patch
+++ b/meta-resin-pyro/recipes-core/systemd/systemd/0001-core-Don-t-redirect-stdio-to-null-when-running-in-co.patch
@@ -1,0 +1,28 @@
+From 79ad9002612611a4aabfffe6d9c8bca5c7253e4a Mon Sep 17 00:00:00 2001
+From: Andrei Gherzan <andrei@resin.io>
+Date: Mon, 19 Feb 2018 14:06:06 +0000
+Subject: [PATCH] core: Don't redirect stdio to null when running in container
+
+Upstream-status: Rejected [https://github.com/systemd/systemd/pull/8220]
+Signed-off-by: Andrei Gherzan <andrei@resin.io>
+---
+ src/core/main.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/core/main.c b/src/core/main.c
+index 9460261..f4d6410 100644
+--- a/src/core/main.c
++++ b/src/core/main.c
+@@ -1531,7 +1531,8 @@ int main(int argc, char *argv[]) {
+                  * need to do that for user instances since they never log
+                  * into the console. */
+                 log_show_color(colors_enabled());
+-                r = make_null_stdio();
++                if (detect_container() <= 0)
++                        r = make_null_stdio();
+                 if (r < 0)
+                         log_warning_errno(r, "Failed to redirect standard streams to /dev/null: %m");
+         }
+--
+2.7.4
+

--- a/meta-resin-pyro/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-resin-pyro/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
+
+SRC_URI_append = " \
+	file://0001-core-Don-t-redirect-stdio-to-null-when-running-in-co.patch \
+"


### PR DESCRIPTION
This issue affects console output when running systemd in docker container
because moby doesn't correctly manage POLLHUP hangup. The issue was initially
created in systemd https://github.com/systemd/systemd/pull/4262 and later
redirected to moby https://github.com/moby/moby/issues/27202 .

This affects versions after 232 where fd0 fd1 fd2 are redirected to /dev/null
leaving no file descriptor pointing to /dev/console. When that happens docker,
the pty master, will close the pty and any attempts to open /dev/console will
return EIO.

This patch removes the /dev/null redirection when running in container. We can
get rid of it when moby fixes the issue referenced above.

Change-type: patch
CHangelog-entry: Fix console output when running resinOS with systemd >= 232
Signed-off-by: Andrei Gherzan <andrei@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
