### PR TITLE
base-files: Package /lib/modules directory

### DIFF
--- a/meta-resin-common/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-resin-common/recipes-core/base-files/base-files_%.bbappend
@@ -4,4 +4,8 @@ do_install_append () {
 	if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
 		rm -f ${D}${sysconfdir}/mtab
 	fi
+
+	# Supervisor depends on the existance of /lib/modules even if we don't
+	# deploy any kernel modules (ex.: resinOS in container)
+	install -d -m 755 ${D}/lib/modules
 }


### PR DESCRIPTION
Resin supervisor expects /lib/modules in places and bind mounts it in the user
container. Make sure we package this directory to avoid runtime error.

Change-type: patch
Changelog-entry: Always have /lib/modules directory in rootfs as supervisor requires it
Signed-off-by: Andrei Gherzan <andrei@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
