### PR TITLE
linux-firmware: Have 8000c package before others

### DIFF
--- a/meta-resin-pyro/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
+++ b/meta-resin-pyro/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
@@ -8,6 +8,6 @@ python __anonymous() {
 	for p in packages.split():
 		if p == "linux-firmware-iwlwifi-8000c":
 			return
-	d.setVar("PACKAGES", packages + " linux-firmware-iwlwifi-8000c")
+	d.setVar("PACKAGES", "linux-firmware-iwlwifi-8000c " + packages)
 }
 FILES_${PN}-iwlwifi-8000c = "${nonarch_base_libdir}/firmware/iwlwifi-8000C-*.ucode"


### PR DESCRIPTION
If this is not the case, other packages will include the files which should get
into the 8000c.

Change-type: patch
CHangelog-entry: Fix 8000c in PACKAGES
Signed-off-by: Andrei Gherzan <andrei@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
