### PR TITLE
Use the correct, full yocto CC/CXX variables when using go

### DIFF
--- a/meta-resin-common/recipes-containers/balena/balena_git.bb
+++ b/meta-resin-common/recipes-containers/balena/balena_git.bb
@@ -91,8 +91,8 @@ do_compile() {
 
   # Pass the needed cflags/ldflags so that cgo
   # can find the needed headers files and libraries
-  export CGO_CFLAGS="${CFLAGS} ${TARGET_CC_ARCH} --sysroot=${STAGING_DIR_TARGET}"
-  export CGO_LDFLAGS="${LDFLAGS}  ${TARGET_CC_ARCH} --sysroot=${STAGING_DIR_TARGET}"
+  export CGO_CFLAGS="${CFLAGS} --sysroot=${STAGING_DIR_TARGET}"
+  export CGO_LDFLAGS="${LDFLAGS}  --sysroot=${STAGING_DIR_TARGET}"
 
   export DOCKER_GITCOMMIT="${SRCREV}"
   export DOCKER_BUILDTAGS='exclude_graphdriver_btrfs exclude_graphdirver_zfs exclude_graphdriver_devicemapper'

--- a/meta-resin-fido/recipes-devtools/go-cross/go-1.7.3/0007-fix-cc-cxx-with-multiple-words.patch
+++ b/meta-resin-fido/recipes-devtools/go-cross/go-1.7.3/0007-fix-cc-cxx-with-multiple-words.patch
@@ -1,0 +1,47 @@
+In yocto CC/CXX can have (and will have) multiple words. Take whem all into
+consideration when constructing the gcc command.
+
+Upstream-Status: Pending
+Signed-off-by: Andrei Gherzan <andrei@resin.io>
+
+Index: go/src/cmd/go/build.go
+===================================================================
+--- go.orig/src/cmd/go/build.go
++++ go/src/cmd/go/build.go
+@@ -2990,12 +2990,18 @@ func (b *builder) gccld(p *Package, out
+ func (b *builder) gccCmd(objdir string) []string {
+ 	return b.ccompilerCmd("CC", defaultCC, objdir)
+ }
++func (b *builder) gccCmdFull() []string {
++	return envList("CC", defaultCC)
++}
+
+ // gxxCmd returns a g++ command line prefix
+ // defaultCXX is defined in zdefaultcc.go, written by cmd/dist.
+ func (b *builder) gxxCmd(objdir string) []string {
+ 	return b.ccompilerCmd("CXX", defaultCXX, objdir)
+ }
++func (b *builder) gxxCmdFull() []string {
++	return envList("CXX", defaultCXX)
++}
+
+ // gfortranCmd returns a gfortran command line prefix.
+ func (b *builder) gfortranCmd(objdir string) []string {
+Index: go/src/cmd/go/env.go
+===================================================================
+--- go.orig/src/cmd/go/env.go
++++ go/src/cmd/go/env.go
+@@ -51,10 +51,11 @@ func mkEnv() []envVar {
+
+ 	if goos != "plan9" {
+ 		cmd := b.gccCmd(".")
+-		env = append(env, envVar{"CC", cmd[0]})
++		env = append(env, envVar{"CC", strings.Join(b.gccCmdFull(), " ")})
+ 		env = append(env, envVar{"GOGCCFLAGS", strings.Join(cmd[3:], " ")})
+ 		cmd = b.gxxCmd(".")
+-		env = append(env, envVar{"CXX", cmd[0]})
++		env = append(env, envVar{"CXX", strings.Join(b.gxxCmdFull(), " ")})
++
+ 	}
+
+ 	if buildContext.CgoEnabled {

--- a/meta-resin-fido/recipes-devtools/go-cross/go_1.7.3.inc
+++ b/meta-resin-fido/recipes-devtools/go-cross/go_1.7.3.inc
@@ -17,4 +17,5 @@ SRC_URI += " \
     file://0004-runtime-don-t-hard-code-physical-page-size.patch \
     file://0005-syscall-make-Getpagesize-return-page-size-from-runti.patch \
     file://0006-runtime-debug-enable-TestFreeOSMemory-on-all-arches.patch \
+    file://0007-fix-cc-cxx-with-multiple-words.patch \
 "

--- a/meta-resin-jethro/recipes-devtools/go-cross/go-1.7.3/0007-fix-cc-cxx-with-multiple-words.patch
+++ b/meta-resin-jethro/recipes-devtools/go-cross/go-1.7.3/0007-fix-cc-cxx-with-multiple-words.patch
@@ -1,0 +1,47 @@
+In yocto CC/CXX can have (and will have) multiple words. Take whem all into
+consideration when constructing the gcc command.
+
+Upstream-Status: Pending
+Signed-off-by: Andrei Gherzan <andrei@resin.io>
+
+Index: go/src/cmd/go/build.go
+===================================================================
+--- go.orig/src/cmd/go/build.go
++++ go/src/cmd/go/build.go
+@@ -2990,12 +2990,18 @@ func (b *builder) gccld(p *Package, out
+ func (b *builder) gccCmd(objdir string) []string {
+ 	return b.ccompilerCmd("CC", defaultCC, objdir)
+ }
++func (b *builder) gccCmdFull() []string {
++	return envList("CC", defaultCC)
++}
+
+ // gxxCmd returns a g++ command line prefix
+ // defaultCXX is defined in zdefaultcc.go, written by cmd/dist.
+ func (b *builder) gxxCmd(objdir string) []string {
+ 	return b.ccompilerCmd("CXX", defaultCXX, objdir)
+ }
++func (b *builder) gxxCmdFull() []string {
++	return envList("CXX", defaultCXX)
++}
+
+ // gfortranCmd returns a gfortran command line prefix.
+ func (b *builder) gfortranCmd(objdir string) []string {
+Index: go/src/cmd/go/env.go
+===================================================================
+--- go.orig/src/cmd/go/env.go
++++ go/src/cmd/go/env.go
+@@ -51,10 +51,11 @@ func mkEnv() []envVar {
+
+ 	if goos != "plan9" {
+ 		cmd := b.gccCmd(".")
+-		env = append(env, envVar{"CC", cmd[0]})
++		env = append(env, envVar{"CC", strings.Join(b.gccCmdFull(), " ")})
+ 		env = append(env, envVar{"GOGCCFLAGS", strings.Join(cmd[3:], " ")})
+ 		cmd = b.gxxCmd(".")
+-		env = append(env, envVar{"CXX", cmd[0]})
++		env = append(env, envVar{"CXX", strings.Join(b.gxxCmdFull(), " ")})
++
+ 	}
+
+ 	if buildContext.CgoEnabled {

--- a/meta-resin-jethro/recipes-devtools/go-cross/go_1.7.3.inc
+++ b/meta-resin-jethro/recipes-devtools/go-cross/go_1.7.3.inc
@@ -17,4 +17,5 @@ SRC_URI += " \
     file://0004-runtime-don-t-hard-code-physical-page-size.patch \
     file://0005-syscall-make-Getpagesize-return-page-size-from-runti.patch \
     file://0006-runtime-debug-enable-TestFreeOSMemory-on-all-arches.patch \
+    file://0007-fix-cc-cxx-with-multiple-words.patch \
 "

--- a/meta-resin-krogoth/recipes-devtools/go-cross/go-1.7.3/0007-fix-cc-cxx-with-multiple-words.patch
+++ b/meta-resin-krogoth/recipes-devtools/go-cross/go-1.7.3/0007-fix-cc-cxx-with-multiple-words.patch
@@ -1,0 +1,47 @@
+In yocto CC/CXX can have (and will have) multiple words. Take whem all into
+consideration when constructing the gcc command.
+
+Upstream-Status: Pending
+Signed-off-by: Andrei Gherzan <andrei@resin.io>
+
+Index: go/src/cmd/go/build.go
+===================================================================
+--- go.orig/src/cmd/go/build.go
++++ go/src/cmd/go/build.go
+@@ -2990,12 +2990,18 @@ func (b *builder) gccld(p *Package, out
+ func (b *builder) gccCmd(objdir string) []string {
+ 	return b.ccompilerCmd("CC", defaultCC, objdir)
+ }
++func (b *builder) gccCmdFull() []string {
++	return envList("CC", defaultCC)
++}
+
+ // gxxCmd returns a g++ command line prefix
+ // defaultCXX is defined in zdefaultcc.go, written by cmd/dist.
+ func (b *builder) gxxCmd(objdir string) []string {
+ 	return b.ccompilerCmd("CXX", defaultCXX, objdir)
+ }
++func (b *builder) gxxCmdFull() []string {
++	return envList("CXX", defaultCXX)
++}
+
+ // gfortranCmd returns a gfortran command line prefix.
+ func (b *builder) gfortranCmd(objdir string) []string {
+Index: go/src/cmd/go/env.go
+===================================================================
+--- go.orig/src/cmd/go/env.go
++++ go/src/cmd/go/env.go
+@@ -51,10 +51,11 @@ func mkEnv() []envVar {
+
+ 	if goos != "plan9" {
+ 		cmd := b.gccCmd(".")
+-		env = append(env, envVar{"CC", cmd[0]})
++		env = append(env, envVar{"CC", strings.Join(b.gccCmdFull(), " ")})
+ 		env = append(env, envVar{"GOGCCFLAGS", strings.Join(cmd[3:], " ")})
+ 		cmd = b.gxxCmd(".")
+-		env = append(env, envVar{"CXX", cmd[0]})
++		env = append(env, envVar{"CXX", strings.Join(b.gxxCmdFull(), " ")})
++
+ 	}
+
+ 	if buildContext.CgoEnabled {

--- a/meta-resin-krogoth/recipes-devtools/go-cross/go_1.7.3.inc
+++ b/meta-resin-krogoth/recipes-devtools/go-cross/go_1.7.3.inc
@@ -17,4 +17,5 @@ SRC_URI += " \
     file://0004-runtime-don-t-hard-code-physical-page-size.patch \
     file://0005-syscall-make-Getpagesize-return-page-size-from-runti.patch \
     file://0006-runtime-debug-enable-TestFreeOSMemory-on-all-arches.patch \
+    file://0007-fix-cc-cxx-with-multiple-words.patch \
 "

--- a/meta-resin-morty/recipes-devtools/go-cross/go-1.7.3/0007-fix-cc-cxx-with-multiple-words.patch
+++ b/meta-resin-morty/recipes-devtools/go-cross/go-1.7.3/0007-fix-cc-cxx-with-multiple-words.patch
@@ -1,0 +1,47 @@
+In yocto CC/CXX can have (and will have) multiple words. Take whem all into
+consideration when constructing the gcc command.
+
+Upstream-Status: Pending
+Signed-off-by: Andrei Gherzan <andrei@resin.io>
+
+Index: go/src/cmd/go/build.go
+===================================================================
+--- go.orig/src/cmd/go/build.go
++++ go/src/cmd/go/build.go
+@@ -2990,12 +2990,18 @@ func (b *builder) gccld(p *Package, out
+ func (b *builder) gccCmd(objdir string) []string {
+ 	return b.ccompilerCmd("CC", defaultCC, objdir)
+ }
++func (b *builder) gccCmdFull() []string {
++	return envList("CC", defaultCC)
++}
+
+ // gxxCmd returns a g++ command line prefix
+ // defaultCXX is defined in zdefaultcc.go, written by cmd/dist.
+ func (b *builder) gxxCmd(objdir string) []string {
+ 	return b.ccompilerCmd("CXX", defaultCXX, objdir)
+ }
++func (b *builder) gxxCmdFull() []string {
++	return envList("CXX", defaultCXX)
++}
+
+ // gfortranCmd returns a gfortran command line prefix.
+ func (b *builder) gfortranCmd(objdir string) []string {
+Index: go/src/cmd/go/env.go
+===================================================================
+--- go.orig/src/cmd/go/env.go
++++ go/src/cmd/go/env.go
+@@ -51,10 +51,11 @@ func mkEnv() []envVar {
+
+ 	if goos != "plan9" {
+ 		cmd := b.gccCmd(".")
+-		env = append(env, envVar{"CC", cmd[0]})
++		env = append(env, envVar{"CC", strings.Join(b.gccCmdFull(), " ")})
+ 		env = append(env, envVar{"GOGCCFLAGS", strings.Join(cmd[3:], " ")})
+ 		cmd = b.gxxCmd(".")
+-		env = append(env, envVar{"CXX", cmd[0]})
++		env = append(env, envVar{"CXX", strings.Join(b.gxxCmdFull(), " ")})
++
+ 	}
+
+ 	if buildContext.CgoEnabled {

--- a/meta-resin-morty/recipes-devtools/go-cross/go_1.7.3.inc
+++ b/meta-resin-morty/recipes-devtools/go-cross/go_1.7.3.inc
@@ -17,4 +17,5 @@ SRC_URI += " \
     file://0004-runtime-don-t-hard-code-physical-page-size.patch \
     file://0005-syscall-make-Getpagesize-return-page-size-from-runti.patch \
     file://0006-runtime-debug-enable-TestFreeOSMemory-on-all-arches.patch \
+    file://0007-fix-cc-cxx-with-multiple-words.patch \
 "


### PR DESCRIPTION
Connected to https://github.com/resin-os/meta-resin/issues/919
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
