### PR TITLE
docker-disk: Fix compile error

### DIFF
--- a/meta-resin-common/recipes-containers/docker-disk/files/entry.sh
+++ b/meta-resin-common/recipes-containers/docker-disk/files/entry.sh
@@ -43,7 +43,9 @@ if [ -n "${TARGET_REPOSITORY}" ] && [ -n "${TARGET_TAG}" ]; then
 fi
 
 echo "Stopping docker..."
-kill -TERM "$(cat /var/run/docker.pid)" && wait "$(cat /var/run/docker.pid)"
+kill -TERM "$(cat /var/run/docker.pid)"
+# don't let wait() error out and crash the build if the docker daemon has already been stopped
+wait $(cat /var/run/docker.pid) || true
 
 # Make all files owned by the build system
 chown -R "$USER_ID:$USER_GID" "$DATA_VOLUME"


### PR DESCRIPTION
when not including any docker image

When building without the resin-supervisor (unmanaged production build for example)
then we do not include the supervisor image. In such a case, if we also do not bundle in
any container, the entry.sh script will not do any "docker pull" commands and then when sending
SIGTERM to the docker daemon it will shutdown immediately so that the subsequent wait() will
error out.

Change-type: patch
Changelog-entry: Fix docker-disk when not including any docker image
Signed-off-by: Florin Sarbu <florin@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
