### PR TITLE
kernel-resin.bbclass: Add missing dependency for leds-gpio

### DIFF
--- a/meta-resin-common/classes/kernel-resin.bbclass
+++ b/meta-resin-common/classes/kernel-resin.bbclass
@@ -241,6 +241,7 @@ RESIN_CONFIGS[brcmfmac] ?= " \
 RESIN_CONFIGS_DEPS[leds-gpio] ?= " \
     CONFIG_NEW_LEDS=y \
     CONFIG_LEDS_CLASS=y \
+    CONFIG_GPIOLIB=y \
     "
 RESIN_CONFIGS[leds-gpio] ?= " \
     CONFIG_LEDS_GPIO=y \


### PR DESCRIPTION
Change-type: patch
Changelog-entry: Add missing kernel config dependency for leds-gpio
Signed-off-by: Andrei Gherzan <andrei@resin.io>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
