### PR TITLE
docker-disk: Don't leave root files if docker build fails

### DIFF
--- a/meta-resin-common/recipes-containers/docker-disk/files/Dockerfile
+++ b/meta-resin-common/recipes-containers/docker-disk/files/Dockerfile
@@ -1,9 +1,5 @@
 FROM docker:17.03-dind
-
-RUN apk add --update bash util-linux shadow && rm -rf /var/cache/apk/*
-
+RUN apk add --update util-linux shadow && rm -rf /var/cache/apk/*
 ADD entry.sh /entry.sh
-
 RUN chmod a+x /entry.sh
-
 CMD /entry.sh


### PR DESCRIPTION
Change-type: patch
Changelog-entry: Fix docker-disk when docker build fails to not leave root files behind
Signed-off-by: Andrei Gherzan <andrei@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
