### PR TITLE
openvpn: Add alias for old service name

### DIFF
--- a/meta-resin-common/recipes-connectivity/openvpn/openvpn/openvpn.service
+++ b/meta-resin-common/recipes-connectivity/openvpn/openvpn/openvpn.service
@@ -14,4 +14,5 @@ PIDFile=/var/run/openvpn/resin.pid
 ExecStart=/usr/sbin/openvpn --daemon --writepid /var/run/openvpn/resin.pid --cd /etc/openvpn/ --config /run/openvpn/resin.conf
 
 [Install]
+Alias=openvpn-resin.service
 WantedBy=resin.target


### PR DESCRIPTION
We rename resin-openvpn.service to openvpn.service but there are still
components that are using the old name (for example: supervisor). This
patch adds a service alias to the old name.

Change-type: patch
Changelog-entry: Add resin-openvpn.service alias for openvpn.service
Signed-off-by: Andrei Gherzan <andrei@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
