### PR TITLE
disable openvpn tls renegotiation hourly in favour of every 1GB

### DIFF
--- a/meta-resin-common/recipes-connectivity/openvpn/openvpn/resin.conf
+++ b/meta-resin-common/recipes-connectivity/openvpn/openvpn/resin.conf
@@ -22,3 +22,6 @@ persist-tun
 verb 3
 user openvpn
 group openvpn
+
+reneg-sec 0
+reneg-bytes 1073741824


### PR DESCRIPTION
openvpn: disable tls renegotiation hourly in favour of every 1GB

This discourages all clients from rekeying their sessions at the same time, which in turn causes vpn/api load spikes.

Fixes #1023
Change-Type: patch
Changelog-Entry: disable openvpn time-based tls key renegotiation
Signed-off-by: Will Boyce <will@resin.io>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)