### PR TITLE
resinhup: make docker image cleanup more effective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Resinhup: make docker image cleanup more effective at the end of update [Gergely]
 * Update supervisor to v6.2.9 [Pablo]
 * Resinhup: allow cached pull of the resinhup updater container as well [Gergely]
 * Resinhup: run supervisor update to the release version by default and add negative flag [Gergely]

--- a/meta-resin-common/recipes-support/resinhup/resinhup/run-resinhup.sh
+++ b/meta-resin-common/recipes-support/resinhup/resinhup/run-resinhup.sh
@@ -220,11 +220,16 @@ function runPreHacks {
     fi
 }
 
+function dockerCleanRepo {
+    local repo=$1
+    $DOCKER images --no-trunc | grep "${repo}" | awk '{ print $3 }' | uniq | xargs -t $DOCKER rmi -f  &> /dev/null 2>&1 || true
+}
+
 function runPostHacks {
     log "Cleanup docker images..."
-    $DOCKER rmi -f $RESINHUP_REGISTRY:$TAG-$SLUG  &> /dev/null
-    $DOCKER rmi -f registry.resinstaging.io/resin/resinos:$HOSTOS_VERSION-$SLUG &> /dev/null
-    $DOCKER rmi -f resin/resinos:$HOSTOS_VERSION-$SLUG &> /dev/null
+    dockerCleanRepo "$RESINHUP_REGISTRY"
+    dockerCleanRepo "registry.resinstaging.io/resin/resinos"
+    dockerCleanRepo "resin/resinos"
 
     # This is just an optimization so next time docker starts it won't have to index everything
     # risking the systemd service to timeout.


### PR DESCRIPTION
Sometime in resinHUP we need to clean up images. Doing `rce rm -f`
using a tag does not clean everything up, if there are multiple
imaages for the same hash, with different tags. In that case, the
specific one will be untagged, but the rest stay there.

In resinHUP, actually sometimes multiple tags of the same image
are on the device. For example this is observed in an actual update:
```
registry.resinstaging.io/resin/resinhup     latest-raspberrypi3    79d36e224b23        7 months ago         105 MB
registry.resinstaging.io/resin/resinhup     v1.2.1-raspberry-pi2   79d36e224b23        7 months ago         105 MB
registry.resinstaging.io/resin/resinhup     v1.2.1-raspberrypi3    79d36e224b23        7 months ago         105 MB
registry.resinstaging.io/resin/resinhup     latest-raspberry-pi2   79d36e224b23        7 months ago         105 MB
```
and here the updater would remove `registry.resinstaging.io/resin/resinhup:v1.2.1-raspberry-pi2`
only directly, while leaving the rest behind.

This change removes all tags for a specific docker image/repo,
in the above case it would be removing all `registry.resinstaging.io/resin/resinhup`
images.

This should speed up the docker 1.10 migration somewhat, as less
data is there to migrate.

Change-type: patch
Signed-off-by: Gergely Imreh <imrehg@gmail.com>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
