### PR TITLE
kernel-resin.bbclass: Enable CONFIG_USB_ACM as module by default

### DIFF
--- a/meta-resin-common/classes/kernel-resin.bbclass
+++ b/meta-resin-common/classes/kernel-resin.bbclass
@@ -64,6 +64,7 @@ RESIN_DEFCONFIG_NAME ?= "resin-defconfig"
 RESIN_CONFIGS ?= " \
     balena \
     brcmfmac \
+    cdc-acm \
     ralink \
     r8188eu \
     systemd \
@@ -397,6 +398,11 @@ RESIN_CONFIGS[zram] = " \
     CONFIG_ZRAM=m \
     CONFIG_CRYPTO=y \
     CONFIG_CRYPTO_LZO=m \
+    "
+
+# USB Modem (CDC ACM) support
+RESIN_CONFIGS[cdc-acm] = " \
+    CONFIG_USB_ACM=m \
     "
 
 ###########


### PR DESCRIPTION
Tested on Raspberry Pi 3 and Intel NUC builds.

Fixes #1033

Change-type: patch
Changelog-entry: USB Modem (CDC ACM) support enabled as kernel module
Signed-off-by: Andrei Gherzan <andrei@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
