### PR TITLE
resin-persistent-logs: Fix persistent logging

### DIFF
--- a/meta-resin-common/recipes-support/resin-persistent-logs/resin-persistent-logs/resin-persistent-logs
+++ b/meta-resin-common/recipes-support/resin-persistent-logs/resin-persistent-logs/resin-persistent-logs
@@ -5,6 +5,7 @@ set -e
 . /usr/sbin/resin-vars
 
 if [ "$PERSISTENT_LOGGING" = "true" ] && [ ! -d /var/log/journal ]; then
+    mkdir -p /var/log/journal
     systemctl start bind-var-log-journal.service
     journalctl --flush
     echo "$(basename "$0"): Persistent logging activated."


### PR DESCRIPTION
Fixes #1035

Mount systemd units create directories when not available. We switched to
service units based on bindmount tool which expects the destination to be in
place. This change fixes this by making sure /var/log/journal is in place
before starting the bind mount service.

Change-type: Patch
Changelog-entry: Fix persistent logging
Signed-off-by: Andrei Gherzan <andrei@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
