### PR TITLE
resin-proxy-config: Use iptables PREROUTING instead of OUTPUT to also…

### DIFF
--- a/meta-resin-common/recipes-connectivity/resin-proxy-config/resin-proxy-config/resin-proxy-config
+++ b/meta-resin-common/recipes-connectivity/resin-proxy-config/resin-proxy-config/resin-proxy-config
@@ -18,7 +18,7 @@ REDSOCKSCONF=${CONFIG_PATH%/*}/system-proxy/redsocks.conf
 NOPROXYFILE=${CONFIG_PATH%/*}/system-proxy/no_proxy
 
 # Always clear the REDSOCKS chain if it exists (in case we're restarting with a changed configuration)
-iptables -t nat -D OUTPUT -p tcp -j REDSOCKS || true
+iptables -t nat -D PREROUTING -p tcp -j REDSOCKS || true
 iptables -t nat -F REDSOCKS || true
 iptables -t nat -X REDSOCKS || true
 
@@ -54,4 +54,4 @@ iptables -t nat -A REDSOCKS -d 192.168.0.0/16 -j RETURN
 iptables -t nat -A REDSOCKS -d 224.0.0.0/4 -j RETURN
 iptables -t nat -A REDSOCKS -d 240.0.0.0/4 -j RETURN
 iptables -t nat -A REDSOCKS -p tcp -j REDIRECT --to-ports 12345
-iptables -t nat -A OUTPUT -p tcp -j REDSOCKS
+iptables -t nat -A PREROUTING -p tcp -j REDSOCKS


### PR DESCRIPTION
… redirect traffic coming from containers on custom docker networks

Connects-to: https://github.com/resin-io/hq/issues/1258
Changelog-entry: Fix connectivity with a network proxy in containers on custom docker networks
Change-Type: patch
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>

(still untested)

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
