### PR TITLE
initrdscripts: Make machineid wait with timeout for label to appear

### DIFF
--- a/meta-resin-common/recipes-core/initrdscripts/files/machineid
+++ b/meta-resin-common/recipes-core/initrdscripts/files/machineid
@@ -7,6 +7,19 @@ machineid_enabled() {
         return 1
     fi
 
+    start="$(date +%s)"
+    end="$(date +%s)"
+    while [ ! -L "/dev/disk/by-label/resin-state" ]; do
+        if [ $((end - start)) -le 30 ]; then
+            sleep 1
+            end="$(date +%s)"
+        else
+            echo "[ERROR] Timeout while waiting for resin-state label to appear."
+            echo "[ERROR] Not able to mount resin-state, machine-id will not be persistent"
+            return 1
+        fi
+    done
+
     if ! mount -t ext4 /dev/disk/by-label/resin-state "$ROOTFS_DIR"/mnt/state; then
         echo "[ERROR] Not able to mount resin-state, machine-id will not be persistent"
         return 1


### PR DESCRIPTION
Change-type: patch
Changelog-entry: Fix racing issue of state label existance in initramfs
Signed-off-by: Andrei Gherzan <andrei@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
