### PR TITLE
docker-resin-supervisor-disk: Update to v7.1.20

### DIFF
--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk.bb
@@ -10,7 +10,7 @@ SUPERVISOR_REPOSITORY_x86 = "resin/i386-supervisor"
 SUPERVISOR_REPOSITORY_x86-64 = "resin/amd64-supervisor"
 SUPERVISOR_REPOSITORY_intel-quark = "resin/i386-nlp-supervisor"
 
-SUPERVISOR_TAG ?= "v7.1.18"
+SUPERVISOR_TAG ?= "v7.1.20"
 TARGET_REPOSITORY ?= "${SUPERVISOR_REPOSITORY}"
 TARGET_TAG ?= "${SUPERVISOR_TAG}"
 LED_FILE ?= "/dev/null"


### PR DESCRIPTION
Brings in the following improvements since 7.1.18:

- Replace the gosuper component with a node module that handles communication with systemd, and stop using an init system in the supervisor container
- Remove any leftover knex migrations locks before running migrations

Change-type: patch
Changelog-Entry: Update supervisor to v7.1.20
Signed-off-by: Akis Kesoglou <akis@resin.io>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)