### PR TITLE
resin-state-reset: Allow not existing supervisor.conf file

### DIFF
--- a/meta-resin-common/recipes-support/resin-state-reset/resin-state-reset/resin-state-reset
+++ b/meta-resin-common/recipes-support/resin-state-reset/resin-state-reset/resin-state-reset
@@ -11,7 +11,10 @@ rm -rf ${RESIN_STATE_MP}/root-overlay
 # We need to stop doing this in the future by using cache file in the state
 # partition
 mkdir -p -- "/mnt/state/root-overlay/etc/resin-supervisor/"
-cp -- "/etc/resin-supervisor/supervisor.conf" "/mnt/state/root-overlay/etc/resin-supervisor/"
+if [ -f "/etc/resin-supervisor/supervisor.conf" ]
+then
+    cp -- "/etc/resin-supervisor/supervisor.conf" "/mnt/state/root-overlay/etc/resin-supervisor/"
+fi
 
 # Make sure everything is on disk otherwise the flag 'remove_me_to_reset'
 # might end up before other data on state partition. If so, in the case of a


### PR DESCRIPTION
Prevent failure by testing for /etc/resin-supervisor/supervisor.conf
file existence before copying.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
