### PR TITLE
redsocks: patch to be able to use libevent 2.1.x

### DIFF
--- a/meta-resin-common/recipes-connectivity/redsocks/files/0001-using-libevent-2_1_x.patch
+++ b/meta-resin-common/recipes-connectivity/redsocks/files/0001-using-libevent-2_1_x.patch
@@ -1,0 +1,33 @@
+From 792a06ba87621b3c9e921c7fd080cb350ff6892b Mon Sep 17 00:00:00 2001
+From: Apollon Oikonomopoulos <apoikos@debian.org>
+Date: Thu, 29 Mar 2018 22:50:56 +0300
+Subject: [PATCH] Fix redsocks_evbuffer_readline with libevent 2.1
+
+_EVENT_NUMERIC_VERSION was renamed to EVENT__NUMERIC_VERSION in libevent
+2.1. As a result, redsocks_evbuffer_readline would end up using
+evbuffer_readline(buf), which causes client connections to hang
+indefinitely.
+
+Switch the check to using LIBEVENT_VERSION_NUMBER instead.
+LIBEVENT_VERSION_NUMBER has been around since libevent 2.0.3 and
+redsocks is already using it in other parts of the code.
+
+Upstream-Status: Pending
+
+---
+ utils.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/utils.c b/utils.c
+index 824d0cc..30ee290 100644
+--- a/utils.c
++++ b/utils.c
+@@ -117,7 +117,7 @@ int redsocks_gettimeofday(struct timeval *tv)
+ 
+ char *redsocks_evbuffer_readline(struct evbuffer *buf)
+ {
+-#if _EVENT_NUMERIC_VERSION >= 0x02000000
++#if LIBEVENT_VERSION_NUMBER >= 0x02000000
+ 	return evbuffer_readln(buf, NULL, EVBUFFER_EOL_CRLF);
+ #else
+ 	return evbuffer_readline(buf);

--- a/meta-resin-common/recipes-connectivity/redsocks/redsocks_0.5.bb
+++ b/meta-resin-common/recipes-connectivity/redsocks/redsocks_0.5.bb
@@ -5,7 +5,10 @@ LIC_FILES_CHKSUM="file://README;beginline=74;endline=78;md5=edd3a93090d9025f47a1
 
 SRCREV = "27b17889a43e32b0c1162514d00967e6967d41bb"
 
-SRC_URI = "git://github.com/darkk/redsocks.git"
+SRC_URI = " \
+    git://github.com/darkk/redsocks.git \
+    file://0001-using-libevent-2_1_x.patch \
+"
 
 DEPENDS = "libevent"
 


### PR DESCRIPTION
Current version of redsocks cannot use libevent 2.1.x because of a breaking change, and that results in the `http-connect` (and possibly other) operation being broken (regression since meta-resin 2.10.0)

This commit pulls in a proposed patch from redsocks:  https://github.com/darkk/redsocks/pull/123

This should fix https://github.com/resin-os/resinos/issues/461 and has been tested with a custom build.

Change-type: patch
Changelog-entry: Apply upstream patch for redsocks to fix http-config regression
Signed-off-by: Gergely Imreh <imrehg@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
