### PR TITLE
update-resin-supervisor: Allow running update when no API endpoint is…

### DIFF
--- a/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/update-resin-supervisor
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-resin-supervisor-disk/update-resin-supervisor
@@ -60,11 +60,6 @@ done
 # A temporary file used until next reboot
 UPDATECONF=/tmp/update-supervisor.conf
 
-if [ -z "$API_ENDPOINT" ]; then
-    echo "Environment variable API_ENDPOINT must be set."
-    exit 1
-fi
-
 # If the user api key exists we use it instead of the deviceApiKey as it means we haven't done the key exchange yet
 _device_api_key=${PROVISIONING_API_KEY:-$DEVICE_API_KEY}
 if [ -z "$_device_api_key" ]; then
@@ -73,6 +68,7 @@ if [ -z "$_device_api_key" ]; then
 fi
 
 error_handler() {
+    # shellcheck disable=SC2181
     [ $? -eq 0 ] && exit 0
 
     # If docker pull fails, start the old supervisor again and exit
@@ -99,7 +95,7 @@ fi
 # The script will exit if curl does not get a valid response.
 # Getting data separately before reading it fixes error handling.
 echo "Getting image name and tag..."
-if data=$(curl --silent --header "User-Agent:" --compressed "$API_ENDPOINT/v3/supervisor_release?\$select=supervisor_version,image_name&\$filter=should_manage__device/any(d:d/id%20eq%20$DEVICE_ID)&apikey=$_device_api_key" | jq -e -r '.d[0].supervisor_version,.d[0].image_name'); then
+if [ -n "$API_ENDPOINT" ] && [ -n "$DEVICE_ID" ] && [ -n "$_device_api_key" ] && data=$(curl --silent --header "User-Agent:" --compressed "$API_ENDPOINT/v3/supervisor_release?\$select=supervisor_version,image_name&\$filter=should_manage__device/any(d:d/id%20eq%20$DEVICE_ID)&apikey=$_device_api_key" | jq -e -r '.d[0].supervisor_version,.d[0].image_name'); then
     echo "Supervisor configuration found from API."
 
     if [ -n "$UPDATER_SUPERVISOR_TAG" ] || [ -n "$UPDATER_SUPERVISOR_IMAGE" ]; then
@@ -119,7 +115,7 @@ if data=$(curl --silent --header "User-Agent:" --compressed "$API_ENDPOINT/v3/su
         error_handler "no tag received"
     fi
 else
-    echo "No supervisor configuration found from API. Using arguments for image and tag."
+    echo "No supervisor configuration found from API or required variables not set. Using arguments for image and tag."
     # shellcheck disable=SC1091
     . /etc/resin-supervisor/supervisor.conf
     if [ -z "$UPDATER_SUPERVISOR_TAG" ]; then


### PR DESCRIPTION
… available

In unmanaged images, the API endpoint is not available while in resinOS
in container the supervisor is not preloaded. This means that when
running resinOS in container, the supervisor will get pulled in by the
updater only if the image is configured for resin.io connectivity (it
includes API endpoint). This makes resinOS in container not usable
(without tweaking) when running resinOS in container without config.json
resin.io configuration.

This change lets the update run even when no API_ENDPOINT is available
in which case the updater will just pull the version specified in
supervisor.conf.

Change-type: patch
Changelog-entry: Allow update resin spervisor when API endpoint is not available
Signed-off-by: Andrei Gherzan <andrei@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
