### PR TITLE
resin-mount: Fixing typo

### DIFF
--- a/meta-resin-common/recipes-support/resin-mounts/resin-mounts.inc
+++ b/meta-resin-common/recipes-support/resin-mounts/resin-mounts.inc
@@ -42,8 +42,8 @@ do_compile () {
 		if [ "$bindmount" = "/var/lib/systemd" ]; then
 			# Systemd services need to write to /var/lib/systemd so make sure
 			# that is mounted.
-			sed -i -e "/^Before=/s/\$/ systemd-random-seed.service systemd-rfkill.service systemd-timesyncd/" \
-			-e "/^WantedBy=/s/\$/ systemd-random-seed.service systemd-rfkill.service systemd-timesyncd/" \
+			sed -i -e "/^Before=/s/\$/ systemd-random-seed.service systemd-rfkill.service systemd-timesyncd.service/" \
+			-e "/^WantedBy=/s/\$/ systemd-random-seed.service systemd-rfkill.service systemd-timesyncd.service/" \
 			$servicefile
 		elif [ "$bindmount" = "/var/log/journal" ]; then
 			# This bind mount is only invoked manually in persistent logs


### PR DESCRIPTION
resin-mounts.inc are missing the "service" prefix to the systemd unit file of systemd-timesyncd.

Signed-off-by: Mans Zigher <mans.zigher@gmail.com>
