### PR TITLE
Adds teensy udev rules to resin extra udev rules

### DIFF
--- a/meta-resin-common/recipes-core/packagegroups/packagegroup-resin.inc
+++ b/meta-resin-common/recipes-core/packagegroups/packagegroup-resin.inc
@@ -10,6 +10,7 @@ RDEPENDS_${PN} = " \
     ${RESIN_INIT_PACKAGE} \
     ${RESIN_MOUNTS} \
     ${RESIN_REGISTER} \
+    resin-extra-udev-rules \
     rsync \
     kernel-modules \
     os-release \

--- a/meta-resin-common/recipes-core/resin-extra-udev-rules/files/49-teensy.rules
+++ b/meta-resin-common/recipes-core/resin-extra-udev-rules/files/49-teensy.rules
@@ -1,0 +1,38 @@
+# UDEV Rules for Teensy boards, http://www.pjrc.com/teensy/
+#
+# The latest version of this file may be found at:
+#   http://www.pjrc.com/teensy/49-teensy.rules
+#
+# This file must be placed at:
+#
+# /etc/udev/rules.d/49-teensy.rules    (preferred location)
+#   or
+# /lib/udev/rules.d/49-teensy.rules    (req'd on some broken systems)
+#
+# To install, type this command in a terminal:
+#   sudo cp 49-teensy.rules /etc/udev/rules.d/49-teensy.rules
+#
+# Or use the alternate way (from this forum message) to download and install:
+#   https://forum.pjrc.com/threads/45595?p=150445&viewfull=1#post150445
+#
+# After this file is installed, physically unplug and reconnect Teensy.
+#
+ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789B]?", ENV{ID_MM_DEVICE_IGNORE}="1"
+ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789A]?", ENV{MTP_NO_PROBE}="1"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789ABCD]?", MODE:="0666"
+KERNEL=="ttyACM*", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789B]?", MODE:="0666"
+#
+# If you share your linux system with other users, or just don't like the
+# idea of write permission for everybody, you can replace MODE:="0666" with
+# OWNER:="yourusername" to create the device owned by you, or with
+# GROUP:="somegroupname" and mange access using standard unix groups.
+#
+#
+# If using USB Serial you get a new device each time (Ubuntu 9.10)
+# eg: /dev/ttyACM0, ttyACM1, ttyACM2, ttyACM3, ttyACM4, etc
+#    apt-get remove --purge modemmanager     (reboot may be necessary)
+#
+# Older modem proding (eg, Ubuntu 9.04) caused very slow serial device detection.
+# To fix, add this near top of /lib/udev/rules.d/77-nm-probe-modem-capabilities.rules
+#   SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789]?", GOTO="nm_modem_probe_end"
+#

--- a/meta-resin-common/recipes-core/resin-extra-udev-rules/resin-extra-udev-rules.bb
+++ b/meta-resin-common/recipes-core/resin-extra-udev-rules/resin-extra-udev-rules.bb
@@ -1,0 +1,14 @@
+SUMMARY = "Teensy udev rules"
+DESCRIPTION = "Rules to prevent ModemManager attempting to use Teensy boards as a modem"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${RESIN_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+inherit allarch
+
+FILESEXTRAPATHS_append := ":${THISDIR}/files"
+
+SRC_URI_append = " file://49-teensy.rules"
+
+do_install_append() {
+    install -D -m 0644 ${WORKDIR}/49-teensy.rules ${D}/lib/udev/rules.d/
+}

--- a/meta-resin-common/recipes-core/resin-extra-udev-rules/resin-extra-udev-rules.bb
+++ b/meta-resin-common/recipes-core/resin-extra-udev-rules/resin-extra-udev-rules.bb
@@ -10,5 +10,5 @@ FILESEXTRAPATHS_append := ":${THISDIR}/files"
 SRC_URI_append = " file://49-teensy.rules"
 
 do_install_append() {
-    install -D -m 0644 ${WORKDIR}/49-teensy.rules ${D}/lib/udev/rules.d/
+    install -D -m 0644 ${WORKDIR}/49-teensy.rules ${D}/lib/udev/rules.d/49-teensy.rules
 }


### PR DESCRIPTION
This PR relates to issue #1063 to add teensy udev rules.

These changes add the [49-teensy.rules](https://www.pjrc.com/teensy/49-teensy.rules) within a connectivity recipe called `resin-extra-udev-rules`. The recipe attempts to copy [resin-edison/.../modemmanager.bbappend](https://github.com/resin-os/resin-edison/blob/master/layers/meta-resin-edison/recipes-connectivity/modemmanager/modemmanager_%25.bbappend) to add the required rules. However, uses a `bb` file as this is not modifying the existing modem manager.

I was considering whether adding the udev rules from a URL with a md4 checksum would have been more appropriate. This would mean that were the rules ever updated the process would fail and mean that the new rules could be reviewed. Having the rules copied directly into the repo is stable however could become out of date.

I have not ever written a `bb` file and not written any tests for this PR so please point me in the right direction to correct where required.