### PR TITLE
Add support for updating ntp servers from dhcp

### DIFF
--- a/meta-resin-common/recipes-connectivity/networkmanager/files/99dhcp_ntp
+++ b/meta-resin-common/recipes-connectivity/networkmanager/files/99dhcp_ntp
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+case "$2" in
+	dhcp4-change|up)
+	if [ -z "$DHCP4_NTP_SEVERS" ]; then
+		echo '[Time]' > /etc/systemd/timesyncd.conf
+		echo "NTP=$DHCP4_NTP_SERVERS" >> /etc/systemd/timesyncd.conf
+		echo 'FallbackNTP=0.resinio.pool.ntp.org 1.resinio.pool.ntp.org 2.resinio.pool.ntp.org 3.resinio.pool.ntp.org ' >> /etc/systemd/timesyncd.conf
+		systemctl daemon-reload
+		systemctl restart systemd-timesyncd
+	fi
+	;;
+	*)
+	;;
+esac
+

--- a/meta-resin-common/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/meta-resin-common/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -7,6 +7,7 @@ FILESEXTRAPATHS_append := ":${THISDIR}/files"
 SRC_URI_append = " \
     file://NetworkManager.conf.systemd \
     file://NetworkManager.conf \
+    file://99dhcp_ntp \
     file://README.ignore \
     file://resin-sample.ignore \
     file://nm-tmpfiles.conf \
@@ -30,6 +31,8 @@ do_install_append() {
     install -m 0644 ${WORKDIR}/nm-tmpfiles.conf ${D}${sysconfdir}/tmpfiles.d/
 
     install -m 0644 ${WORKDIR}/NetworkManager.conf ${D}${sysconfdir}/NetworkManager/
+    mkdir -p "${sysconfdir}/NetworkManager/dispatcher.d/"
+    install -m 0755 ${WORKDIR}/99dhcp_ntp ${D}${sysconfdir}/NetworkManager/dispatcher.d/
 
     if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
         install -d ${D}${sysconfdir}/systemd/system/NetworkManager.service.d


### PR DESCRIPTION
Currently, any ntp server recommended by the dhcp server
is ignored.

This patch adds a NetworkManager dispatcher script which runs
after any connection event is triggered. If there is an ntp
server recommendation received via dhcp, the script updates
timesynd.conf and restarts the timesyncd daemon.

Change-type: patch
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@resin.io>

Fixes #1068 

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
