### PR TITLE
resin-extra-udev-rules: Instruct ModemManager to ignore STM32F407 devices

### DIFF
--- a/meta-resin-common/recipes-core/resin-extra-udev-rules/files/99-misc.rules
+++ b/meta-resin-common/recipes-core/resin-extra-udev-rules/files/99-misc.rules
@@ -1,0 +1,6 @@
+#
+# Miscellaneous rules
+#
+
+# 0483:5740 - STM32F4 Discovery in USB Serial Mode (CN5)
+ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", ENV{ID_MM_DEVICE_IGNORE}="1"

--- a/meta-resin-common/recipes-core/resin-extra-udev-rules/resin-extra-udev-rules.bb
+++ b/meta-resin-common/recipes-core/resin-extra-udev-rules/resin-extra-udev-rules.bb
@@ -6,9 +6,13 @@ inherit allarch
 
 SRC_URI = " \
 	file://49-teensy.rules \
+	file://99-misc.rules \
 	"
 
 do_install_append() {
 	# Rules to prevent ModemManager attempting to use Teensy boards as a modem
 	install -D -m 0644 ${WORKDIR}/49-teensy.rules ${D}/lib/udev/rules.d/49-teensy.rules
+
+	# Install miscellaneous rules file
+	install -D -m 0644 ${WORKDIR}/99-misc.rules ${D}/lib/udev/rules.d/99-misc.rules
 }


### PR DESCRIPTION
Fixes #1089

ChangeType: patch
Changelog-entry: Set ModemManager to ignore STM32F407 devices
Signed-off-by: Andrei Gherzan <andrei@resin.io>

Testing was only done at the level of build - no hardware available.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
