### PR TITLE
balena_git.bb: Fix mobynit runtime crash when

### DIFF
--- a/meta-resin-common/recipes-containers/balena/balena_git.bb
+++ b/meta-resin-common/recipes-containers/balena/balena_git.bb
@@ -44,6 +44,9 @@ inherit systemd go pkgconfig
 DEPENDS_remove_class-native = "go-cross-native"
 DEPENDS_append_class-native = " go-native"
 
+# By default no extra LDFLAGS needed when compiling mobynit
+MOBYNIT_EXTRA_LDFLAGS ??= ""
+
 do_configure() {
 }
 
@@ -101,7 +104,7 @@ do_compile() {
 
   # Compile mobynit
   cd .gopath/src/"${DOCKER_PKG}"/cmd/mobynit
-  go build -ldflags '-extldflags "-static"' .
+  go build -ldflags '-extldflags "-static ${MOBYNIT_EXTRA_LDFLAGS}"' .
   cd -
 }
 

--- a/meta-resin-sumo/recipes-containers/balena/balena_git.bbappend
+++ b/meta-resin-sumo/recipes-containers/balena/balena_git.bbappend
@@ -1,0 +1,3 @@
+# Since gcc 7.3.0, compiling mobynit with pie support fails at runtime. We
+# deactivate it until we figure out why that happens.
+MOBYNIT_EXTRA_LDFLAGS_append = " -no-pie"


### PR DESCRIPTION
compiled with gcc 7.3.0 with static PIE support enabled

mobyinit is the init we use in resinOS. It is a static golang binary. When compiling
mobynit on a Yocto platform that uses gcc 7.3.0 (Yocto Sumo) with static PIE enabled,
mobynit will crash at runtime and the kernel will panic:

[    4.672896] Kernel panic - not syncing: Attempted to kill init! exitcode=0x0000000b
[    4.672896]
[    4.682177] CPU: 3 PID: 1 Comm: init Not tainted 4.9.80 #2
[    4.687735] Hardware name: BCM2835
[    4.691198] [<80111b44>] (unwind_backtrace) from [<8010d094>] (show_stack+0x20/0x24)
[    4.699054] [<8010d094>] (show_stack) from [<804aa7ac>] (dump_stack+0xcc/0x110)
[    4.706471] [<804aa7ac>] (dump_stack) from [<80216b00>] (panic+0x104/0x274)
[    4.713534] [<80216b00>] (panic) from [<80124068>] (complete_and_exit+0x0/0x2c)
[    4.720947] [<80124068>] (complete_and_exit) from [<80124104>] (do_group_exit+0x50/0xe4)
[    4.729154] [<80124104>] (do_group_exit) from [<8012fa10>] (get_signal+0x39c/0x710)
[    4.736922] [<8012fa10>] (get_signal) from [<8010c2b4>] (do_signal+0xe4/0x3f0)
[    4.744248] [<8010c2b4>] (do_signal) from [<8010c7b4>] (do_work_pending+0xc4/0xdc)
[    4.751927] [<8010c7b4>] (do_work_pending) from [<801087a8>] (slow_work_pending+0xc/0x20)
[    4.760223] CPU1: stopping

For reference, here is the gcc 7.3.0 static PIE patch:
https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/?id=c23734c45fb1239406d054039a0f56413b955eb9

Fix for this is to disable PIE for the static golang mobyinit binary since PIE brings no real benefit
in this case.

Change-type: patch
Changelog-entry: Fix mobynit runtime crash when compiled with gcc 7.3.0 with static PIE support enabled
Signed-off-by: Florin Sarbu <florin@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
