### PR TITLE
networkmanager: Set DHCP timeout to infinity for IPv4

### DIFF
--- a/meta-resin-common/recipes-connectivity/networkmanager/files/NetworkManager.conf
+++ b/meta-resin-common/recipes-connectivity/networkmanager/files/NetworkManager.conf
@@ -5,3 +5,6 @@ autoconnect-retries-default=0
 
 [keyfile]
 unmanaged-devices=interface-name:balena*;interface-name:br*;type:tun;type:veth
+
+[connection]
+ipv4.dhcp-timeout=2147483647


### PR DESCRIPTION
We switch the DHCP IPv4 request timeout to infinity so that we circumvent
situations when the DHCP server times out for long periods of time during
which the lease may also expire and thus when the DHCP server is restored
NetworkManager will not retry at that point as the timeout interval may be
long expired.

We set the timeout to 2147483647 which is basically MAXINT32, but NM will
efectively never timeout in fact.

Change-type: patch
Changelog-entry: Set DHCP timeout to infinity for IPv4
Signed-off-by: Florin Sarbu <florin@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
