### PR TITLE
tini: Fix PIE segfault

### DIFF
--- a/meta-resin-common/recipes-containers/tini/tini_0.14.0.bb
+++ b/meta-resin-common/recipes-containers/tini/tini_0.14.0.bb
@@ -17,9 +17,6 @@ S = "${WORKDIR}/git"
 
 BBCLASSEXTEND = "native"
 
-# tini links with -static, so no PIE for us
-SECURITY_CFLAGS_pn-${PN} = "${SECURITY_NO_PIE_CFLAGS}"
-
 inherit cmake
 
 do_install() {

--- a/meta-resin-krogoth/recipes-containers/tini/tini_0.14.0.bbappend
+++ b/meta-resin-krogoth/recipes-containers/tini/tini_0.14.0.bbappend
@@ -1,0 +1,2 @@
+# No support for static PIE
+SECURITY_CFLAGS_pn-${PN} = "${SECURITY_NO_PIE_CFLAGS}"

--- a/meta-resin-morty/recipes-containers/tini/tini_0.14.0.bbappend
+++ b/meta-resin-morty/recipes-containers/tini/tini_0.14.0.bbappend
@@ -1,0 +1,2 @@
+# No support for static PIE
+SECURITY_CFLAGS_pn-${PN} = "${SECURITY_NO_PIE_CFLAGS}"

--- a/meta-resin-pyro/recipes-containers/tini/tini_0.14.0.bbappend
+++ b/meta-resin-pyro/recipes-containers/tini/tini_0.14.0.bbappend
@@ -1,0 +1,2 @@
+# No support for static PIE
+SECURITY_CFLAGS_pn-${PN} = "${SECURITY_NO_PIE_CFLAGS}"

--- a/meta-resin-rocko/recipes-containers/tini/tini_0.14.0.bbappend
+++ b/meta-resin-rocko/recipes-containers/tini/tini_0.14.0.bbappend
@@ -1,0 +1,2 @@
+# No support for static PIE
+SECURITY_CFLAGS_pn-${PN} = "${SECURITY_NO_PIE_CFLAGS}"

--- a/meta-resin-sumo/recipes-containers/tini/tini_0.14.0.bbappend
+++ b/meta-resin-sumo/recipes-containers/tini/tini_0.14.0.bbappend
@@ -1,0 +1,2 @@
+# Sumo static PIE seems broken as binary gets into segfault at runtime
+SECURITY_CFLAGS_pn-${PN} = "${SECURITY_NOPIE_CFLAGS}"


### PR DESCRIPTION
Even though the GCC in sumo comes with static PIE support, this functionality
looks broken as it fails at runtime with segfault: Program received signal
SIGSEGV, Segmentation fault.
        _dl_relocate_static_pie () at /usr/src/debug/glibc/2.27-r0/git/elf/dl-reloc-static-pie.c:41
        41    /usr/src/debug/glibc/2.27-r0/git/elf/dl-reloc-static-pie.c: No such file or directory.

Tini is compiled with PIE because since sumo update, PIE is enabled by default:

commit 6733a7873ca121295a2e309a6915b9816e1ae36b
Author: Khem Raj <raj.khem@gmail.com>
Date:   Sat Jun 10 07:57:34 2017 -0700
    security_flags.inc: Delete pinnings for SECURITY_NO_PIE_CFLAGS

Fix this by passing the `no pie` flags in sumo and avoiding passing pie flags
in all the older versions.

Change-type: patch
Changelog-entry: Fix tini segfault after sumo update
Signed-off-by: Andrei Gherzan <andrei@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
