### PR TITLE
tini: Avoid overwriting SECURITY_CFLAGS

### DIFF
--- a/meta-resin-krogoth/recipes-containers/tini/tini_0.14.0.bbappend
+++ b/meta-resin-krogoth/recipes-containers/tini/tini_0.14.0.bbappend
@@ -1,2 +1,2 @@
 # No support for static PIE
-SECURITY_CFLAGS_pn-${PN} = "${SECURITY_NO_PIE_CFLAGS}"
+SECURITY_CFLAGS_pn-${PN} += "${SECURITY_NO_PIE_CFLAGS}"

--- a/meta-resin-morty/recipes-containers/tini/tini_0.14.0.bbappend
+++ b/meta-resin-morty/recipes-containers/tini/tini_0.14.0.bbappend
@@ -1,2 +1,2 @@
 # No support for static PIE
-SECURITY_CFLAGS_pn-${PN} = "${SECURITY_NO_PIE_CFLAGS}"
+SECURITY_CFLAGS_pn-${PN} += "${SECURITY_NO_PIE_CFLAGS}"

--- a/meta-resin-pyro/recipes-containers/tini/tini_0.14.0.bbappend
+++ b/meta-resin-pyro/recipes-containers/tini/tini_0.14.0.bbappend
@@ -1,2 +1,2 @@
 # No support for static PIE
-SECURITY_CFLAGS_pn-${PN} = "${SECURITY_NO_PIE_CFLAGS}"
+SECURITY_CFLAGS_pn-${PN} += "${SECURITY_NO_PIE_CFLAGS}"

--- a/meta-resin-rocko/recipes-containers/tini/tini_0.14.0.bbappend
+++ b/meta-resin-rocko/recipes-containers/tini/tini_0.14.0.bbappend
@@ -1,2 +1,2 @@
 # No support for static PIE
-SECURITY_CFLAGS_pn-${PN} = "${SECURITY_NO_PIE_CFLAGS}"
+SECURITY_CFLAGS_pn-${PN} += "${SECURITY_NO_PIE_CFLAGS}"

--- a/meta-resin-sumo/recipes-containers/tini/tini_0.14.0.bbappend
+++ b/meta-resin-sumo/recipes-containers/tini/tini_0.14.0.bbappend
@@ -1,2 +1,2 @@
 # Sumo static PIE seems broken as binary gets into segfault at runtime
-SECURITY_CFLAGS_pn-${PN} = "${SECURITY_NOPIE_CFLAGS}"
+SECURITY_CFLAGS_pn-${PN} += "${SECURITY_NOPIE_CFLAGS}"


### PR DESCRIPTION
Change-type: patch
Changelog-entry: Avoid overwriting SECURITY_CFLAGS for tini recipe
Signed-off-by: Andrei Gherzan <andrei@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
