### PR TITLE
resin-image: Fix fingerprints

### DIFF
--- a/meta-resin-common/recipes-core/images/resin-image.bb
+++ b/meta-resin-common/recipes-core/images/resin-image.bb
@@ -49,7 +49,7 @@ generate_hostos_version () {
 
 DEPENDS += "jq-native"
 
-IMAGE_PREPROCESS_COMMAND += " generate_rootfs_fingerprints ; "
+IMAGE_PREPROCESS_COMMAND_append = " generate_rootfs_fingerprints ; "
 IMAGE_POSTPROCESS_COMMAND += " generate_hostos_version ; "
 
 RESIN_BOOT_PARTITION_FILES_append = " \


### PR DESCRIPTION
Since rocko update, this commit ended up in poky:

	commit bb81ff1343d8d6213f0418fd18b10312c96c4617
	Author: Richard Purdie <richard.purdie@linuxfoundation.org>
	Date:   Fri Aug 11 08:10:33 2017 +0100
	    image-prelink: Disable for musl images

This switched the use of `+=` to `_append` when adding the prelink hooks to
IMAGE_PREPROCESS_COMMAND. Because we are using `+=` for adding our fingerprints
hook, we end up having the prelink hooks after the fingerprints one (append is
evaluated after parsing - see
https://www.yoctoproject.org/docs/1.6/bitbake-user-manual/bitbake-user-manual.html#appending-and-prepending-override-style-syntax).
This results in wrong artifacts when prelink modifies the binaries - rootfs
ends up with wrong fingerprints. We fix this be using `_append` as well.

Change-type: patch
Changelog-entry: Fix rootfs fingerprints on poky rocko or newer
Signed-off-by: Andre Gherzan <andrei@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
