### PR TITLE
resin-supervisor: Add runtime dependency on docker-disk

### DIFF
--- a/meta-resin-common/recipes-containers/resin-supervisor/resin-supervisor.bb
+++ b/meta-resin-common/recipes-containers/resin-supervisor/resin-supervisor.bb
@@ -35,6 +35,7 @@ RDEPENDS_${PN} = " \
 	balena \
 	coreutils \
 	curl \
+	docker-disk \
 	healthdog \
 	resin-unique-key \
 	resin-vars \


### PR DESCRIPTION
This supervisor script package needs at runtime the actual docker image which has
the supervisor embedded into it.

Change-type: patch
Changelog-entry: Make resin-supervisor runtime depend on docker-disk
Signed-off-by: Florin Sarbu <florin@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
