### PR TITLE
Add support for Automated OS Rollbacks

### DIFF
--- a/meta-resin-common/recipes-bsp/u-boot/patches/env_resin.h
+++ b/meta-resin-common/recipes-bsp/u-boot/patches/env_resin.h
@@ -81,9 +81,24 @@
                        "run resin_import_env_file;" \
                "fi;\0" \
        \
+       "resin_check_altroot=" \
+              "setexpr resin_roota ${resin_boot_part} + 1; " \
+              "setexpr resin_rootb ${resin_boot_part} + 2; " \
+              "if test -n ${bootlimit}; then " \
+                      "if test ${bootcount} -gt ${bootlimit}; then " \
+                               "echo WARNING! BOOTLIMIT EXCEEDED. SWITCHING TO PREVIOUS ROOTFS; " \
+                               "if test ${resin_root_part} -eq ${resin_roota}; then "\
+                                       "env set resin_root_part ${resin_rootb}; " \
+                                "else; "\
+                                       "env set resin_root_part ${resin_roota}; " \
+                                "fi;" \
+                      "fi;" \
+              "fi;\0" \
+       \
        "resin_set_kernel_root=" \
                "run resin_set_dev_index;" \
                "run resin_inject_env_file;" \
+               "run resin_check_altroot;" \
                "run resin_find_root_part_uuid;" \
                "setenv resin_kernel_root root=PARTUUID=${resin_root_part_uuid}\0"
 

--- a/meta-resin-common/recipes-containers/balena/balena/balena-host.service
+++ b/meta-resin-common/recipes-containers/balena/balena/balena-host.service
@@ -3,7 +3,7 @@ Description=Balena Application Container Engine (host)
 Documentation=https://www.balena.io/docs/getting-started
 Wants=dnsmasq.service
 Requires=mnt-sysroot-active.service mnt-sysroot-inactive.service
-After=network.target mnt-sysroot-active.service mnt-sysroot-inactive.service dnsmasq.service
+After=network.target mnt-sysroot-active.service mnt-sysroot-inactive.service dnsmasq.service rollback-altboot.service
 ConditionVirtualization=!docker
 
 [Service]

--- a/meta-resin-common/recipes-containers/balena/balena/balena.service
+++ b/meta-resin-common/recipes-containers/balena/balena/balena.service
@@ -3,7 +3,7 @@ Description=Balena Application Container Engine
 Documentation=https://www.balena.io/docs/getting-started
 Wants=dnsmasq.service
 Requires=balena.socket var-lib-docker.mount bind-etc-docker.service bind-home-root-.docker.service
-After=network.target balena.socket var-lib-docker.mount bind-etc-docker.service bind-home-root-.docker.service dnsmasq.service
+After=network.target balena.socket var-lib-docker.mount bind-etc-docker.service bind-home-root-.docker.service dnsmasq.service rollback-altboot.service
 
 [Service]
 Type=notify

--- a/meta-resin-common/recipes-containers/hostapp-update/files/hostapp-update
+++ b/meta-resin-common/recipes-containers/hostapp-update/files/hostapp-update
@@ -27,6 +27,16 @@ fi
 export DOCKER_HOST="unix:///var/run/balena-host.sock"
 SYSROOT="/mnt/sysroot/inactive"
 
+if [ -d /mnt/state ]; then
+	# Save VPN state for rollbacks
+	if [ -e /var/run/openvpn/vpn_status/active ]; then
+		echo "BALENAOS_ROLLBACK_VPNONLINE=1" > /mnt/state/rollback-health-variables ;
+	else
+		echo "BALENAOS_ROLLBACK_VPNONLINE=0" > /mnt/state/rollback-health-variables ;
+	fi
+	sync -f /mnt/state
+fi
+
 # Initialize sysroot
 mkdir -p /mnt/sysroot
 for dir in 'dev' 'etc' 'balena' 'hostapps' 'mnt/state' 'proc' 'sbin' 'sys' 'tmp'; do

--- a/meta-resin-common/recipes-core/balena-rollback/balena-rollback.bb
+++ b/meta-resin-common/recipes-core/balena-rollback/balena-rollback.bb
@@ -1,0 +1,47 @@
+# Copyright 2018 Resinio Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DESCRIPTION = "BalenaOS Rollback services"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${RESIN_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = " \
+    file://rollback-altboot.service \
+    file://rollback-health.service \
+    file://rollback-altboot \
+    file://rollback-health \
+    file://rollback-stop \
+    file://rollback-tests \
+    file://rollback-parse-bootloader \
+    "
+S = "${WORKDIR}"
+
+inherit allarch systemd
+
+SYSTEMD_SERVICE_${PN} = " \
+	rollback-altboot.service \
+	rollback-health.service \
+	"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0775 ${S}/rollback-altboot ${D}${bindir}
+    install -m 0775 ${S}/rollback-health ${D}${bindir}
+    install -m 0775 ${S}/rollback-stop ${D}${bindir}
+    install -m 0775 ${S}/rollback-tests ${D}${bindir}
+    install -m 0775 ${S}/rollback-parse-bootloader ${D}${bindir}
+    install -c -m 0644 ${S}/rollback-altboot.service ${D}${systemd_unitdir}/system
+    install -c -m 0644 ${S}/rollback-health.service ${D}${systemd_unitdir}/system
+}

--- a/meta-resin-common/recipes-core/balena-rollback/files/rollback-altboot
+++ b/meta-resin-common/recipes-core/balena-rollback/files/rollback-altboot
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# Copyright 2018 Resinio Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+
+. /usr/sbin/resin-vars
+. /usr/bin/rollback-parse-bootloader
+
+if [ $resin_root_part -ne $current_part_idx ]; then
+	echo "Rollback: Looks like we are running in atlboot mode. Running hooks to recover bootfiles"
+	DURING_UPDATE=0 /usr/bin/hostapp-update-hooks
+	touch /mnt/state/rollback-altboot-triggered
+	rollback-stop || true
+	echo "Rollback: Rebooting system"
+	sleep 10
+	reboot
+else
+	echo "Rollback: Nothing to do by rollback-altboot.service"
+	echo "Rollback: rollback-health.service will run sanity checks and remove breadcrumbs"
+fi

--- a/meta-resin-common/recipes-core/balena-rollback/files/rollback-altboot.service
+++ b/meta-resin-common/recipes-core/balena-rollback/files/rollback-altboot.service
@@ -1,0 +1,29 @@
+# Copyright 2018 Resinio Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[Unit]
+Description=Ballena rollback checks altboot
+DefaultDependencies=no
+Requires=resin-boot.service mnt-sysroot-active.service mnt-sysroot-inactive.service
+Before=balena-host.service balena.service
+After=mnt-sysroot-active.service mnt-sysroot-inactive.service resin-boot.service
+ConditionPathExists=/mnt/state/rollback-altboot-breadcrumb
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/sh /usr/bin/rollback-altboot
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-resin-common/recipes-core/balena-rollback/files/rollback-health
+++ b/meta-resin-common/recipes-core/balena-rollback/files/rollback-health
@@ -1,0 +1,84 @@
+#!/bin/sh
+#
+# Copyright 2018 Resinio Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+
+. /usr/sbin/resin-vars
+. /usr/bin/rollback-parse-bootloader
+
+TIMEOUT=60
+COUNT=15
+REBOOT_TIMEOUT=900
+
+DURING_UPDATE=${DURING_UPDATE:-0}
+
+run_hooks_from_inactive () {
+	echo "Rollback: Running hooks from previous rootfs"
+	old_rootfs=$(/mnt/sysroot/active/current/boot/init -sysroot /mnt/sysroot/inactive)
+	mount -t proc proc "${old_rootfs}/proc/"
+	mount -o bind /dev "${old_rootfs}/dev"
+	mount --bind /mnt/boot/ "${old_rootfs}/mnt/boot/"
+	mount --bind /mnt/state/ "${old_rootfs}/mnt/state/"
+	mount --bind /mnt/sysroot/ "${old_rootfs}/mnt/sysroot/"
+	mount --bind /mnt/sysroot/active/ "${old_rootfs}/mnt/sysroot/active/"
+	mount --bind /mnt/sysroot/inactive/ "${old_rootfs}/mnt/sysroot/inactive/"
+	mount -t sysfs sysfs "${old_rootfs}/sys/"
+
+	# DURING_UPDATE tells hooks to use the boot files from inactive
+	# which are the good set of files in ROLLBACK_ALTBOOT mode
+	# also tells the bootloaders to switch roots
+	cat << EOF | chroot "${old_rootfs}"
+	DURING_UPDATE=1 /usr/bin/hostapp-update-hooks
+EOF
+}
+
+echo "Rollback: Health sanity check"
+
+if [ $resin_root_part -eq $current_part_idx ]; then
+	if [ $upgrade_available -eq 1 ]; then
+		echo "Rollback: HUP detected. Running healthchecks after $TIMEOUT seconds"
+		sleep $TIMEOUT
+		echo "Rollback: Running healthchecks to see if new system is stable"
+		counter=0
+		while ! rollback-tests ; do
+			echo "Trying healthcheck again $counter of $COUNT attempts"
+			sleep $TIMEOUT
+			counter=$((counter + 1))
+			if [ $counter -ge $COUNT ]; then
+				echo "Rollback: Looks like we failed some health check. Rolling back"
+				run_hooks_from_inactive
+				touch /mnt/state/rollback-health-triggered
+				rollback-stop || true
+				echo "Rollback: Failed heathchecks. Rebooting to previous rootfs"
+				sleep 10
+				reboot
+			fi
+		done
+	    echo "Rollback: new OS seems stable. Preventing further rollbacks"
+	    rollback-stop || true
+
+	else
+		echo "Rollback: Nothing to do. Looks like we are in ROLLBACK_HEALTHY state. Why is script running?"
+		rollback-stop || true
+	fi
+else
+	echo "Rollback: Looks like we are running in altboot mode. rollback-altboot.services should reboot the system in a while."
+	echo "Rollback: Sleeping for $REBOOT_TIMEOUT seconds"
+	sleep $REBOOT_TIMEOUT
+	echo "Rollback: Looks like something bad happened to rollback-altboot.service. Lets force a reboot"
+	rollback-stop || true
+	systemctl --force reboot
+fi

--- a/meta-resin-common/recipes-core/balena-rollback/files/rollback-health.service
+++ b/meta-resin-common/recipes-core/balena-rollback/files/rollback-health.service
@@ -1,0 +1,28 @@
+# Copyright 2018 Resinio Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[Unit]
+Description=Ballena rollback checks health
+DefaultDependencies=no
+Requires=resin-boot.service mnt-sysroot-active.service mnt-sysroot-inactive.service resin-supervisor.service
+After=mnt-sysroot-active.service mnt-sysroot-inactive.service resin-boot.service balena-host.service balena.service resin-supervisor.service
+ConditionPathExists=/mnt/state/rollback-health-breadcrumb
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/sh /usr/bin/rollback-health
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-resin-common/recipes-core/balena-rollback/files/rollback-parse-bootloader
+++ b/meta-resin-common/recipes-core/balena-rollback/files/rollback-parse-bootloader
@@ -1,0 +1,54 @@
+#!/bin/sh
+#
+# Copyright 2018 Resinio Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+
+. /usr/sbin/resin-vars
+
+echo "Rollback: Parsing bootloader configuration"
+
+if [ ! -d "$RESIN_BOOT_MOUNTPOINT" ]; then
+        echo "Rollback: $RESIN_BOOT_MOUNTPOINT doesn't exist."
+        exit 1
+fi
+
+# Fetch bootloader variables into environment
+if [ -f "${RESIN_BOOT_MOUNTPOINT}/resinOS_uEnv.txt" ]; then
+	BOOTLOADER_FILE="${RESIN_BOOT_MOUNTPOINT}/resinOS_uEnv.txt"
+else
+	grub_cfg=$(find "${RESIN_BOOT_MOUNTPOINT}" -name grub.cfg)
+	if [ -f "${grub_cfg}" ]; then
+		BOOTLOADER_FILE="${grub_cfg}"
+	fi
+fi
+
+# Parse bootloader config file for key variables
+upgrade_available=`grep "upgrade_available=" "${BOOTLOADER_FILE}" | cut -d'=' -f 2`
+resin_root_part=`grep "resin_root_part=" "${BOOTLOADER_FILE}" | cut -d'=' -f 2`
+
+if [ -z "${upgrade_available}" ]; then
+	echo "Rollback: Could not find upgrade_available variable in bootloader environment"
+	exit 1
+fi
+
+if [ -z "${resin_root_part}" ]; then
+	echo "Rollback: Could not find resin_root_part variable in bootloader environment"
+	exit 1
+fi
+
+current_part=$(findmnt --noheadings --canonicalize --output SOURCE /mnt/sysroot/active)
+blockdev=$(basename "$current_part")
+current_part_idx=$(cat "/sys/class/block/$blockdev/partition")

--- a/meta-resin-common/recipes-core/balena-rollback/files/rollback-stop
+++ b/meta-resin-common/recipes-core/balena-rollback/files/rollback-stop
@@ -1,0 +1,44 @@
+#!/bin/sh
+#
+# Copyright 2018 Resinio Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+
+. /usr/sbin/resin-vars
+. /usr/bin/rollback-parse-bootloader
+
+echo "Rollback: Stopping further rollbacks"
+echo "Rollback: Setting upgrade_available to 0 and removing breadcrumbs"
+rm -f /mnt/state/rollback-health-variables || true
+rm -f /mnt/state/rollback-altboot-breadcrumb || true
+rm -f /mnt/state/rollback-health-breadcrumb || true
+rm -f "${RESIN_BOOT_MOUNTPOINT}/bootcount.env" || true
+grub_env=$(find "${RESIN_BOOT_MOUNTPOINT}" -name grubenv)
+if [ -f "${grub_env}" ]; then
+	sed -i "s#bootcount=.*#bootcount=0 #g" "${grub_env}" || true
+fi
+sync -f /mnt/state
+sync -f "${RESIN_BOOT_MOUNTPOINT}"
+
+echo "Rollback: Following bootloader file ${BOOTLOADER_FILE} found"
+if [ -f "${BOOTLOADER_FILE}" ]; then
+	cp "${BOOTLOADER_FILE}" "${BOOTLOADER_FILE}.new"
+	sed -i "s#upgrade_available=.*#upgrade_available=0#g" "${BOOTLOADER_FILE}.new"
+	sync -f "${RESIN_BOOT_MOUNTPOINT}"
+	mv "${BOOTLOADER_FILE}.new" "${BOOTLOADER_FILE}"
+fi
+
+sync -f "${RESIN_BOOT_MOUNTPOINT}"
+echo "Rollback: Further rollbacks stopped"

--- a/meta-resin-common/recipes-core/balena-rollback/files/rollback-tests
+++ b/meta-resin-common/recipes-core/balena-rollback/files/rollback-tests
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# Copyright 2018 Resinio Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+
+. /usr/sbin/resin-vars
+
+echo "Rollback: Running tests"
+
+# VPN health check
+if [ -f /mnt/state/rollback-health-variables ]; then
+	. /mnt/state/rollback-health-variables
+	if [ -f /run/openvpn/vpn_status/active ]; then
+		echo "Rollback: VPN is back online in new OS."
+	elif [ $BALENAOS_ROLLBACK_VPNONLINE == 1 ]; then
+		echo "Rollback: ERROR: VPN used to be ok but has not connected!"
+		exit 1
+	elif [ $BALENAOS_ROLLBACK_VPNONLINE == 0 ]; then
+		echo "Rollback: VPN used to be offline before HUP. Not using VPN healthcheck for rollback"
+	fi
+fi
+
+# Balena health check
+if /usr/lib/balena/balena-healthcheck ; then
+	echo "Rollback: Balena looks healthy"
+else
+	echo "Rollback: ERROR: Balena is not healthy!"
+	exit 1
+fi

--- a/meta-resin-common/recipes-core/packagegroups/packagegroup-resin.bb
+++ b/meta-resin-common/recipes-core/packagegroups/packagegroup-resin.bb
@@ -23,6 +23,7 @@ RDEPENDS_${PN} += " \
     resin-hostname \
     resin-state-reset \
     resin-device-progress \
+    balena-rollback \
     timeinit \
     ${@bb.utils.contains('BALENA_STORAGE', 'aufs', 'aufs-util', '', d)} \
     ${RESIN_SUPERVISOR} \

--- a/meta-resin-common/recipes-support/hostapp-update-hooks/files/80-rollback
+++ b/meta-resin-common/recipes-support/hostapp-update-hooks/files/80-rollback
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+#
+# Script which handles automated os rollbacks functionality
+#
+
+set -o errexit
+
+. /usr/sbin/resin-vars
+
+printf "[INFO] Running rollback hook \n"
+
+DURING_UPDATE=${DURING_UPDATE:-0}
+
+if [ ! -d "$RESIN_BOOT_MOUNTPOINT" ]; then
+        echo "hostapp rollback: $RESIN_BOOT_MOUNTPOINT doesn't exist."
+        exit 1
+fi
+
+# Are we updating or falling back?
+if [ "$DURING_UPDATE" = 1 ]; then
+        touch /mnt/state/rollback-health-breadcrumb
+        touch /mnt/state/rollback-altboot-breadcrumb
+        rm -f /mnt/state/rollback-health-triggered || true
+        rm -f /mnt/state/rollback-altboot-triggered || true
+else
+        rm -f /mnt/state/rollback-health-variables || true
+        rm -f /mnt/state/rollback-altboot-breadcrumb || true
+        rm -f /mnt/state/rollback-health-breadcrumb || true
+        rm -f /mnt/state/rollback-health-triggered || true
+        rm -f /mnt/state/rollback-altboot-triggered || true
+fi
+
+sync -f /mnt/state

--- a/meta-resin-common/recipes-support/hostapp-update-hooks/files/99-resin-grub
+++ b/meta-resin-common/recipes-support/hostapp-update-hooks/files/99-resin-grub
@@ -25,7 +25,11 @@ else
 fi
 
 new_part=$(findmnt --noheadings --canonicalize --output SOURCE $SYSROOT)
+blockdev=$(basename "$new_part")
+new_part_idx=$(cat "/sys/class/block/$blockdev/partition")
 new_part_label=$(blkid "$new_part" | awk '{print $2}' | cut -d'"' -f 2)
+
+printf "[INFO] Switching root partition to %s...\n" "$new_part_label..."
 
 # flash legacy grub only if we do not support UEFI
 if [ ! -d /sys/firmware/efi ] ; then
@@ -54,11 +58,20 @@ else
     rm -rf "$RESIN_BOOT_MOUNTPOINT/grub" || true
 fi
 
-printf "[INFO] Switching root partition to %s..." "$new_part_label..."
-grub_cfg=$(find /mnt/boot/ -name grub.cfg)
-sed "s/resin-root./"$new_part_label"/" "$grub_cfg" > "$grub_cfg".new
+grub_cfg=$(find $RESIN_BOOT_MOUNTPOINT -name grub.cfg)
+grub_env=$(find $RESIN_BOOT_MOUNTPOINT -name grubenv)
+
+if  grep -q upgrade_available "$grub_cfg" ; then
+    printf "[INFO] Automated Rollback support in grub.cfg detected \n"
+    sed "s#resin_root_part=.*#resin_root_part="$new_part_idx"#g" "$grub_cfg" > "$grub_cfg".new
+    sed -i "s#upgrade_available=.*#upgrade_available="$DURING_UPDATE"#g" "$grub_cfg".new
+    sed -i "s#bootcount=.*#bootcount=0 #g" "$grub_env"
+else
+    printf "[INFO] Automated Rollback is not supported by grub config file for this device \n"
+    sed "s/resin-root./"$new_part_label"/" "$grub_cfg" > "$grub_cfg".new
+fi
 
 sync -f $(dirname "$grub_cfg")
 mv "$grub_cfg".new "$grub_cfg"
 sync -f $(dirname "$grub_cfg")
-printf " done.\n"
+printf "[INFO] Switch root done.\n"

--- a/meta-resin-common/recipes-support/hostapp-update-hooks/files/99-resin-uboot
+++ b/meta-resin-common/recipes-support/hostapp-update-hooks/files/99-resin-uboot
@@ -20,6 +20,9 @@ new_part_idx=$(cat "/sys/class/block/$blockdev/partition")
 
 printf "[INFO] Switching uboot root partition index to %s..." "$new_part_idx..."
 echo "resin_root_part=$new_part_idx" > /mnt/boot/resinOS_uEnv.txt.new
+echo "upgrade_available=$DURING_UPDATE" >> /mnt/boot/resinOS_uEnv.txt.new
+rm -f /mnt/boot/bootcount.env || true
+
 sync -f /mnt/boot
 mv /mnt/boot/resinOS_uEnv.txt.new /mnt/boot/resinOS_uEnv.txt
 sync -f /mnt/boot

--- a/meta-resin-common/recipes-support/hostapp-update-hooks/hostapp-update-hooks.bb
+++ b/meta-resin-common/recipes-support/hostapp-update-hooks/hostapp-update-hooks.bb
@@ -7,7 +7,7 @@ S = "${WORKDIR}"
 
 inherit allarch
 
-HOSTAPP_HOOKS = "0-bootfiles"
+HOSTAPP_HOOKS = "0-bootfiles 80-rollback"
 RESIN_BOOT_FINGERPRINT = "${RESIN_FINGERPRINT_FILENAME}.${RESIN_FINGERPRINT_EXT}"
 
 python __anonymous() {


### PR DESCRIPTION
This PR adds automated OS rollback recipe.

The rollback structure is as follows

There are 2 scripts rollbacks-altboot and rollbacks-health.
After a HUP, rollbacks-altboot checks if the bootloader bootcount has triggered and the bootloader has run the previous rootfs. If rollbacks-altboot detects we are running the previous rootfs, then rollbacks-altboot tries to recover the bootfiles and reboots.

After a HUP, rollbacks-health checks if the state of the new resin OS is working. The basic check we have at the moment is that the vpn comes back online after a HUP. This is a mandatory requirement of HUP at the moment. This will prevent bricks happening in case modem drivers bugger up e.g.
Again, if rollbacks-health detects that the vpn has not come back online after a timeout, script tries to recover the boot files from the previous rootfs and then reboot.

To enable rollback in devices, devices have to do the following inu-boot (grub way wip)

Enable CONFIG_CMD_SETEXPR, CONFIG_BOOTCOUNT_LIMIT and depending on the
device, save the bootcount in some persistant location whether that
is an area in the SoC or an ext partition etc.

If you are using an ext partition, use only the boot partition and
use the filename rollbacks.env

e.g. for rpi3
CONFIG_CMD_SETEXPR=y
CONFIG_BOOTCOUNT_LIMIT=y
CONFIG_SYS_BOOTCOUNT_ADDR=0x02300000
CONFIG_BOOTCOUNT_EXT=y
CONFIG_SYS_BOOTCOUNT_EXT_DEVPART=0:1
CONFIG_SYS_BOOTCOUNT_EXT_NAME="rollbacks.env"

And a patch that tweaks the BOOTCOUNT_EXT driver and modifies the FS_TYPE_EXT restriction to FS_TYPE_ANY so that we can store rollbacks.env inside the boot partition.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
