### PR TITLE
kernel-modules-headers.bb: Fix missing

### DIFF
--- a/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
+++ b/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
@@ -10,6 +10,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=89aea4e17d99a7cacdbeed46a0096b10"
 DEPENDS = " \
     virtual/kernel \
     bc-native \
+    openssl \
     "
 
 SRC_URI = "git://github.com/resin-os/module-headers.git;protocol=https"


### PR DESCRIPTION
openssl/bio.h when compiling on kernel
version 4.16

Adding the dependency on openssl fixes the following error:

|   HOSTCC  scripts/extract-cert
| scripts/extract-cert.c:21:10: fatal error: openssl/bio.h:
No such file or directory

Change-type: patch
Changelog-entry: Fix kernel-modules-headers compile missing bio.h
Signed-off-by: Florin Sarbu <florin@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
