### PR TITLE
kernel-modules-headers: Update version to v0.0.11

### DIFF
--- a/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
+++ b/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
@@ -11,22 +11,25 @@ DEPENDS = " \
     virtual/kernel \
     bc-native \
     openssl \
+    openssl-native \
     "
 
 SRC_URI = "git://github.com/resin-os/module-headers.git;protocol=https"
 
-SRCREV = "v0.0.10"
+SRCREV = "v0.0.11"
 
 S = "${WORKDIR}/git"
 B = "${WORKDIR}"
 
 inherit deploy kernel-arch
 
+HOSTCC = "${BUILD_CC} ${BUILD_CFLAGS} ${BUILD_LDFLAGS}"
+
 do_configure[noexec] = "1"
 
 do_compile() {
     mkdir -p kernel_modules_headers
-    ${S}/gen_mod_headers ./kernel_modules_headers ${STAGING_KERNEL_DIR} ${DEPLOY_DIR_IMAGE} ${ARCH} ${TARGET_PREFIX} "${CC}"
+    ${S}/gen_mod_headers ./kernel_modules_headers ${STAGING_KERNEL_DIR} ${DEPLOY_DIR_IMAGE} ${ARCH} ${TARGET_PREFIX} "${HOSTCC}"
     tar -czf kernel_modules_headers.tar.gz kernel_modules_headers
     rm -rf kernel_modules_headers
 }


### PR DESCRIPTION
This version uses hostcc (last argument) for modules_prepare as well
(not only for for compiling the scripts). On newer kernel versions,
modules_prepare needs more than just the CC but also sysroot, ld flags
etc. Add all these so tools like extract_cert can be compiled during
modules_prepare.

 Fixes #1143

Change-type: patch
Changelog-entry: Update kernel-modules-headers to v0.0.11
Signed-off-by: Andrei Gherzan <andrei@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
