### PR TITLE
dropbear: Enhanced security options

### DIFF
--- a/meta-resin-krogoth/recipes-core/dropbear/dropbear_2016.72.bbappend
+++ b/meta-resin-krogoth/recipes-core/dropbear/dropbear_2016.72.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += " \
+    file://0001-Secure-configuration-options.patch \
+    "

--- a/meta-resin-krogoth/recipes-core/dropbear/files/0001-Secure-configuration-options.patch
+++ b/meta-resin-krogoth/recipes-core/dropbear/files/0001-Secure-configuration-options.patch
@@ -1,0 +1,53 @@
+From 4d870472eaa5df7eedff35c16a04c2ccb6095c91 Mon Sep 17 00:00:00 2001
+From: Andrei Gherzan <andrei@resin.io>
+Date: Thu, 30 Aug 2018 12:33:08 +0100
+Subject: [PATCH] Secure configuration options
+
+We deactivate various configuration knobs which have security concerns:
+
+* DROPBEAR_X11FWD - no need to run X over ssh
+* DROPBEAR_SHA1_96_HMAC - HMAC 96 is known to be a weak algorithm. It is
+	reported by OpenVAS as a low severity security issue.
+* DROPBEAR_ENABLE_CBC_MODE - As reported by OpenVAS, CBC mode can allow
+	an attacker to obtain plaintext from a block of cyphertext.
+
+Signed-off-by: Andrei Gherzan <andrei@resin.io>
+Upstream-status: Inappropriate [configuration]
+---
+ options.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/options.h b/options.h
+index 94261f6..926952a 100644
+--- a/options.h
++++ b/options.h
+@@ -55,7 +55,7 @@ much traffic. */
+ #define DROPBEAR_SMALL_CODE
+
+ /* Enable X11 Forwarding - server only */
+-#define ENABLE_X11FWD
++/* #define ENABLE_X11FWD */
+
+ /* Enable TCP Fowarding */
+ /* 'Local' is "-L" style (client listening port forwarded via server)
+@@ -100,7 +100,7 @@ much traffic. */
+
+ /* Enable CBC mode for ciphers. This has security issues though
+  * is the most compatible with older SSH implementations */
+-#define DROPBEAR_ENABLE_CBC_MODE
++/* #define DROPBEAR_ENABLE_CBC_MODE */
+
+ /* Enable "Counter Mode" for ciphers. This is more secure than normal
+  * CBC mode against certain attacks. It is recommended for security
+@@ -131,7 +131,7 @@ If you test it please contact the Dropbear author */
+  * If you disable MD5, Dropbear will fall back to SHA1 fingerprints,
+  * which are not the standard form. */
+ #define DROPBEAR_SHA1_HMAC
+-#define DROPBEAR_SHA1_96_HMAC
++/* #define DROPBEAR_SHA1_96_HMAC */
+ #define DROPBEAR_SHA2_256_HMAC
+ #define DROPBEAR_SHA2_512_HMAC
+ #define DROPBEAR_MD5_HMAC
+--
+2.7.4
+

--- a/meta-resin-morty/recipes-core/dropbear/dropbear_2016.74.bbappend
+++ b/meta-resin-morty/recipes-core/dropbear/dropbear_2016.74.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += " \
+    file://0001-Secure-configuration-options.patch \
+    "

--- a/meta-resin-morty/recipes-core/dropbear/files/0001-Secure-configuration-options.patch
+++ b/meta-resin-morty/recipes-core/dropbear/files/0001-Secure-configuration-options.patch
@@ -1,0 +1,65 @@
+From ae62abd529b985130f747277758fa078780aeda6 Mon Sep 17 00:00:00 2001
+From: Andrei Gherzan <andrei@resin.io>
+Date: Thu, 30 Aug 2018 12:33:08 +0100
+Subject: [PATCH] Secure configuration options
+
+We deactivate various configuration knobs which have security concerns:
+
+* DROPBEAR_X11FWD - no need to run X over ssh
+* DROPBEAR_SHA1_96_HMAC - HMAC 96 is known to be a weak algorithm. It is
+	reported by OpenVAS as a low severity security issue.
+* DROPBEAR_ENABLE_CBC_MODE - As reported by OpenVAS, CBC mode can allow
+	an attacker to obtain plaintext from a block of cyphertext.
+* DROPBEAR_DH_GROUP1 - This is documented as "less secure" while in
+	newer versions mentioned as "too small for security". See:
+https://github.com/mkj/dropbear/blob/d740dc548924f2faf0934e5f9a4b83d2b5d6902d/default_options.h#L141
+
+Signed-off-by: Andrei Gherzan <andrei@resin.io>
+Upstream-status: Inappropriate [configuration]
+---
+ options.h | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/options.h b/options.h
+index f6705c6..ec4f414 100644
+--- a/options.h
++++ b/options.h
+@@ -55,7 +55,7 @@ much traffic. */
+ #define DROPBEAR_SMALL_CODE
+
+ /* Enable X11 Forwarding - server only */
+-#define ENABLE_X11FWD
++/* #define ENABLE_X11FWD */
+
+ /* Enable TCP Fowarding */
+ /* 'Local' is "-L" style (client listening port forwarded via server)
+@@ -100,7 +100,7 @@ much traffic. */
+
+ /* Enable CBC mode for ciphers. This has security issues though
+  * is the most compatible with older SSH implementations */
+-#define DROPBEAR_ENABLE_CBC_MODE
++/* #define DROPBEAR_ENABLE_CBC_MODE */
+
+ /* Enable "Counter Mode" for ciphers. This is more secure than normal
+  * CBC mode against certain attacks. It is recommended for security
+@@ -131,7 +131,7 @@ If you test it please contact the Dropbear author */
+  * If you disable MD5, Dropbear will fall back to SHA1 fingerprints,
+  * which are not the standard form. */
+ #define DROPBEAR_SHA1_HMAC
+-#define DROPBEAR_SHA1_96_HMAC
++/* #define DROPBEAR_SHA1_96_HMAC */
+ #define DROPBEAR_SHA2_256_HMAC
+ #define DROPBEAR_SHA2_512_HMAC
+ #define DROPBEAR_MD5_HMAC
+@@ -170,7 +170,7 @@ If you test it please contact the Dropbear author */
+
+ /* Group14 (2048 bit) is recommended. Group1 is less secure (1024 bit) though
+    is the only option for interoperability with some older SSH programs */
+-#define DROPBEAR_DH_GROUP1 1
++#define DROPBEAR_DH_GROUP1 0
+ #define DROPBEAR_DH_GROUP14 1
+
+ /* Control the memory/performance/compression tradeoff for zlib.
+--
+2.7.4
+

--- a/meta-resin-pyro/recipes-core/dropbear/dropbear_2016.74.bbappend
+++ b/meta-resin-pyro/recipes-core/dropbear/dropbear_2016.74.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += " \
+    file://0001-Secure-configuration-options.patch \
+    "

--- a/meta-resin-pyro/recipes-core/dropbear/files/0001-Secure-configuration-options.patch
+++ b/meta-resin-pyro/recipes-core/dropbear/files/0001-Secure-configuration-options.patch
@@ -1,0 +1,65 @@
+From ae62abd529b985130f747277758fa078780aeda6 Mon Sep 17 00:00:00 2001
+From: Andrei Gherzan <andrei@resin.io>
+Date: Thu, 30 Aug 2018 12:33:08 +0100
+Subject: [PATCH] Secure configuration options
+
+We deactivate various configuration knobs which have security concerns:
+
+* DROPBEAR_X11FWD - no need to run X over ssh
+* DROPBEAR_SHA1_96_HMAC - HMAC 96 is known to be a weak algorithm. It is
+	reported by OpenVAS as a low severity security issue.
+* DROPBEAR_ENABLE_CBC_MODE - As reported by OpenVAS, CBC mode can allow
+	an attacker to obtain plaintext from a block of cyphertext.
+* DROPBEAR_DH_GROUP1 - This is documented as "less secure" while in
+	newer versions mentioned as "too small for security". See:
+https://github.com/mkj/dropbear/blob/d740dc548924f2faf0934e5f9a4b83d2b5d6902d/default_options.h#L141
+
+Signed-off-by: Andrei Gherzan <andrei@resin.io>
+Upstream-status: Inappropriate [configuration]
+---
+ options.h | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/options.h b/options.h
+index f6705c6..ec4f414 100644
+--- a/options.h
++++ b/options.h
+@@ -55,7 +55,7 @@ much traffic. */
+ #define DROPBEAR_SMALL_CODE
+
+ /* Enable X11 Forwarding - server only */
+-#define ENABLE_X11FWD
++/* #define ENABLE_X11FWD */
+
+ /* Enable TCP Fowarding */
+ /* 'Local' is "-L" style (client listening port forwarded via server)
+@@ -100,7 +100,7 @@ much traffic. */
+
+ /* Enable CBC mode for ciphers. This has security issues though
+  * is the most compatible with older SSH implementations */
+-#define DROPBEAR_ENABLE_CBC_MODE
++/* #define DROPBEAR_ENABLE_CBC_MODE */
+
+ /* Enable "Counter Mode" for ciphers. This is more secure than normal
+  * CBC mode against certain attacks. It is recommended for security
+@@ -131,7 +131,7 @@ If you test it please contact the Dropbear author */
+  * If you disable MD5, Dropbear will fall back to SHA1 fingerprints,
+  * which are not the standard form. */
+ #define DROPBEAR_SHA1_HMAC
+-#define DROPBEAR_SHA1_96_HMAC
++/* #define DROPBEAR_SHA1_96_HMAC */
+ #define DROPBEAR_SHA2_256_HMAC
+ #define DROPBEAR_SHA2_512_HMAC
+ #define DROPBEAR_MD5_HMAC
+@@ -170,7 +170,7 @@ If you test it please contact the Dropbear author */
+
+ /* Group14 (2048 bit) is recommended. Group1 is less secure (1024 bit) though
+    is the only option for interoperability with some older SSH programs */
+-#define DROPBEAR_DH_GROUP1 1
++#define DROPBEAR_DH_GROUP1 0
+ #define DROPBEAR_DH_GROUP14 1
+
+ /* Control the memory/performance/compression tradeoff for zlib.
+--
+2.7.4
+

--- a/meta-resin-rocko/recipes-core/dropbear/dropbear_2017.75.bbappend
+++ b/meta-resin-rocko/recipes-core/dropbear/dropbear_2017.75.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += " \
+    file://0001-Secure-configuration-options.patch \
+    "

--- a/meta-resin-rocko/recipes-core/dropbear/files/0001-Secure-configuration-options.patch
+++ b/meta-resin-rocko/recipes-core/dropbear/files/0001-Secure-configuration-options.patch
@@ -1,0 +1,65 @@
+From ae62abd529b985130f747277758fa078780aeda6 Mon Sep 17 00:00:00 2001
+From: Andrei Gherzan <andrei@resin.io>
+Date: Thu, 30 Aug 2018 12:33:08 +0100
+Subject: [PATCH] Secure configuration options
+
+We deactivate various configuration knobs which have security concerns:
+
+* DROPBEAR_X11FWD - no need to run X over ssh
+* DROPBEAR_SHA1_96_HMAC - HMAC 96 is known to be a weak algorithm. It is
+	reported by OpenVAS as a low severity security issue.
+* DROPBEAR_ENABLE_CBC_MODE - As reported by OpenVAS, CBC mode can allow
+	an attacker to obtain plaintext from a block of cyphertext.
+* DROPBEAR_DH_GROUP1 - This is documented as "less secure" while in
+	newer versions mentioned as "too small for security". See:
+https://github.com/mkj/dropbear/blob/d740dc548924f2faf0934e5f9a4b83d2b5d6902d/default_options.h#L141
+
+Signed-off-by: Andrei Gherzan <andrei@resin.io>
+Upstream-status: Inappropriate [configuration]
+---
+ options.h | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/options.h b/options.h
+index f6705c6..ec4f414 100644
+--- a/options.h
++++ b/options.h
+@@ -55,7 +55,7 @@ much traffic. */
+ #define DROPBEAR_SMALL_CODE
+
+ /* Enable X11 Forwarding - server only */
+-#define ENABLE_X11FWD
++/* #define ENABLE_X11FWD */
+
+ /* Enable TCP Fowarding */
+ /* 'Local' is "-L" style (client listening port forwarded via server)
+@@ -100,7 +100,7 @@ much traffic. */
+
+ /* Enable CBC mode for ciphers. This has security issues though
+  * is the most compatible with older SSH implementations */
+-#define DROPBEAR_ENABLE_CBC_MODE
++/* #define DROPBEAR_ENABLE_CBC_MODE */
+
+ /* Enable "Counter Mode" for ciphers. This is more secure than normal
+  * CBC mode against certain attacks. It is recommended for security
+@@ -131,7 +131,7 @@ If you test it please contact the Dropbear author */
+  * If you disable MD5, Dropbear will fall back to SHA1 fingerprints,
+  * which are not the standard form. */
+ #define DROPBEAR_SHA1_HMAC
+-#define DROPBEAR_SHA1_96_HMAC
++/* #define DROPBEAR_SHA1_96_HMAC */
+ #define DROPBEAR_SHA2_256_HMAC
+ #define DROPBEAR_SHA2_512_HMAC
+ #define DROPBEAR_MD5_HMAC
+@@ -170,7 +170,7 @@ If you test it please contact the Dropbear author */
+
+ /* Group14 (2048 bit) is recommended. Group1 is less secure (1024 bit) though
+    is the only option for interoperability with some older SSH programs */
+-#define DROPBEAR_DH_GROUP1 1
++#define DROPBEAR_DH_GROUP1 0
+ #define DROPBEAR_DH_GROUP14 1
+
+ /* Control the memory/performance/compression tradeoff for zlib.
+--
+2.7.4
+

--- a/meta-resin-sumo/recipes-core/dropbear/dropbear_2017.75.bbappend
+++ b/meta-resin-sumo/recipes-core/dropbear/dropbear_2017.75.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += " \
+    file://0001-Secure-configuration-options.patch \
+    "

--- a/meta-resin-sumo/recipes-core/dropbear/files/0001-Secure-configuration-options.patch
+++ b/meta-resin-sumo/recipes-core/dropbear/files/0001-Secure-configuration-options.patch
@@ -1,0 +1,65 @@
+From ae62abd529b985130f747277758fa078780aeda6 Mon Sep 17 00:00:00 2001
+From: Andrei Gherzan <andrei@resin.io>
+Date: Thu, 30 Aug 2018 12:33:08 +0100
+Subject: [PATCH] Secure configuration options
+
+We deactivate various configuration knobs which have security concerns:
+
+* DROPBEAR_X11FWD - no need to run X over ssh
+* DROPBEAR_SHA1_96_HMAC - HMAC 96 is known to be a weak algorithm. It is
+	reported by OpenVAS as a low severity security issue.
+* DROPBEAR_ENABLE_CBC_MODE - As reported by OpenVAS, CBC mode can allow
+	an attacker to obtain plaintext from a block of cyphertext.
+* DROPBEAR_DH_GROUP1 - This is documented as "less secure" while in
+	newer versions mentioned as "too small for security". See:
+https://github.com/mkj/dropbear/blob/d740dc548924f2faf0934e5f9a4b83d2b5d6902d/default_options.h#L141
+
+Signed-off-by: Andrei Gherzan <andrei@resin.io>
+Upstream-status: Inappropriate [configuration]
+---
+ options.h | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/options.h b/options.h
+index f6705c6..ec4f414 100644
+--- a/options.h
++++ b/options.h
+@@ -55,7 +55,7 @@ much traffic. */
+ #define DROPBEAR_SMALL_CODE
+
+ /* Enable X11 Forwarding - server only */
+-#define ENABLE_X11FWD
++/* #define ENABLE_X11FWD */
+
+ /* Enable TCP Fowarding */
+ /* 'Local' is "-L" style (client listening port forwarded via server)
+@@ -100,7 +100,7 @@ much traffic. */
+
+ /* Enable CBC mode for ciphers. This has security issues though
+  * is the most compatible with older SSH implementations */
+-#define DROPBEAR_ENABLE_CBC_MODE
++/* #define DROPBEAR_ENABLE_CBC_MODE */
+
+ /* Enable "Counter Mode" for ciphers. This is more secure than normal
+  * CBC mode against certain attacks. It is recommended for security
+@@ -131,7 +131,7 @@ If you test it please contact the Dropbear author */
+  * If you disable MD5, Dropbear will fall back to SHA1 fingerprints,
+  * which are not the standard form. */
+ #define DROPBEAR_SHA1_HMAC
+-#define DROPBEAR_SHA1_96_HMAC
++/* #define DROPBEAR_SHA1_96_HMAC */
+ #define DROPBEAR_SHA2_256_HMAC
+ #define DROPBEAR_SHA2_512_HMAC
+ #define DROPBEAR_MD5_HMAC
+@@ -170,7 +170,7 @@ If you test it please contact the Dropbear author */
+
+ /* Group14 (2048 bit) is recommended. Group1 is less secure (1024 bit) though
+    is the only option for interoperability with some older SSH programs */
+-#define DROPBEAR_DH_GROUP1 1
++#define DROPBEAR_DH_GROUP1 0
+ #define DROPBEAR_DH_GROUP14 1
+
+ /* Control the memory/performance/compression tradeoff for zlib.
+--
+2.7.4
+


### PR DESCRIPTION
We deactivate various configuration knobs which have security concerns:

* DROPBEAR_X11FWD - no need to run X over ssh
* DROPBEAR_SHA1_96_HMAC - HMAC 96 is known to be a weak algorithm. It is
        reported by OpenVAS as a low severity security issue.
* DROPBEAR_ENABLE_CBC_MODE - As reported by OpenVAS, CBC mode can allow
        an attacker to obtain plaintext from a block of cyphertext.
* DROPBEAR_DH_GROUP1 - This is documented as "less secure" while in
        newer versions mentioned as "too small for security".

Fixes #1161

Change-type: minor
Changelog-entry: Enhanced security options for dropbear
Signed-off-by: Andrei Gherzan <andrei@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
