### PR TITLE
resin-proxy-config: The no_proxy file fails to parse when missing EOL

### DIFF
--- a/meta-resin-common/recipes-connectivity/resin-proxy-config/resin-proxy-config/resin-proxy-config
+++ b/meta-resin-common/recipes-connectivity/resin-proxy-config/resin-proxy-config/resin-proxy-config
@@ -43,10 +43,8 @@ iptables -t nat -A REDSOCKS -m owner --uid-owner redsocks -j RETURN
 
 # Use every line in the no_proxy file as an IP/subnet to not redirect through redsocks
 if [ -f "$NOPROXYFILE" ]; then
-	while read -r line; do
-		if [ ! -z "$line" ]; then
-			iptables -t nat -A REDSOCKS -d "$line" -j RETURN
-		fi
+	while IFS= read -r line || [ -n "${line}" ]; do
+		iptables -t nat -A REDSOCKS -d "$line" -j RETURN		
 	done < "$NOPROXYFILE"
 fi
 


### PR DESCRIPTION
Make sure the reading of the lines in the no_proxy file still return a
line if it is the last one in the file and it doesn't have a newline
at the end.

Connects-to: #1164
Change-type: minor
Signed-off-by: Rich Bayliss <rich@resin.io>
---- Autogenerated Waffleboard Connection: Connects to #1164