### PR TITLE
resin-supervisor.service: Rework dependency on balena.service

### DIFF
--- a/meta-resin-common/recipes-containers/resin-supervisor/resin-supervisor/resin-supervisor.service
+++ b/meta-resin-common/recipes-containers/resin-supervisor/resin-supervisor/resin-supervisor.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Resin supervisor
 Requires=\
-    balena.service \
     resin\x2ddata.mount \
     resin-device-uuid.service \
     os-config-devicekey.service \
@@ -14,6 +13,7 @@ After=\
     bind-etc-systemd-system-resin.target.wants.service \
     bind-etc-resin-supervisor.service \
     chronyd.service
+Wants=balena.service
 
 [Service]
 Type=simple
@@ -23,6 +23,7 @@ WatchdogSec=60
 EnvironmentFile=/etc/resin-supervisor/supervisor.conf
 EnvironmentFile=-/tmp/update-supervisor.conf
 ExecStartPre=-@BINDIR@/balena stop resin_supervisor
+ExecStartPre=/bin/systemctl is-active balena.service
 ExecStart=/usr/bin/healthdog --healthcheck=/usr/lib/resin-supervisor/resin-supervisor-healthcheck @BINDIR@/start-resin-supervisor
 ExecStop=-@BINDIR@/balena stop resin_supervisor
 


### PR DESCRIPTION
As highlighted in
https://lists.freedesktop.org/archives/systemd-devel/
2015-July/033513.html
we now have a problem if balena.service fails initially but afterwards
it succeeds. In such a case, resin-supervisor.service will fail with a
dependency error and won't get restarted later on automatically.

Change-type: patch
Changelog-entry: Rework resin-supervisor systemd dependency on balena
Signed-off-by: Florin Sarbu <florin@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
