### PR TITLE
Add kernel to rootfs 2

### DIFF
--- a/meta-resin-common/recipes-support/hostapp-update-hooks/files/99-resin-grub
+++ b/meta-resin-common/recipes-support/hostapp-update-hooks/files/99-resin-grub
@@ -15,11 +15,11 @@ else
 fi
 
 new_part=$(findmnt --noheadings --canonicalize --output SOURCE $SYSROOT)
-new_part_label=$(blkid "$new_part" | awk '{print $2}')
+new_part_label=$(blkid "$new_part" | awk '{print $2}' | cut -d'"' -f 2)
 
 printf "[INFO] Switching root partition to %s..." "$new_part_label..."
 grub_cfg=$(find /mnt/boot/ -name grub.cfg)
-sed "s/root=[^ ]* /"root=$new_part_label" /" "$grub_cfg" > "$grub_cfg".new
+sed "s/resin-root./"$new_part_label"/" "$grub_cfg" > "$grub_cfg".new
 
 sync -f $(dirname "$grub_cfg")
 mv "$grub_cfg".new "$grub_cfg"


### PR DESCRIPTION
This commit got left out from https://github.com/resin-os/meta-resin/pull/1153

Tested on a nuc in virtualbox

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
