### PR TITLE
kernel-resin.bbclass: Add support for aufs 4.14.56+

### DIFF
--- a/meta-resin-common/classes/kernel-resin.bbclass
+++ b/meta-resin-common/classes/kernel-resin.bbclass
@@ -530,6 +530,7 @@ python do_kernel_resin_aufs_fetch_and_unpack() {
         ('4.12', 'f10d5231965a149c965f4f384e8506a182049ec5'),
         ('4.13', '28589f833b433a1a7d3cb8302328f0596f6354ad'),
         ('4.14', 'b6d4fac971fb30f8f1cc8e5bc350c895ff127003'),
+        ('4.14.56+', '0aa036f91cc8966049d37bd83f4ee134de1c06ca'),
         ('4.15', '7b7739c49c3604f7593d2e179e3ef4a6985793fd'),
         ('4.16', 'd1f68430296fdb5a0d9202b0b8f9b4031d2225a4'),
         ('4.17', '347f3498aa3ad0a7e272c9032f375e5444edb37f'),

--- a/meta-resin-common/recipes-support/hostapp-update-hooks/files/99-resin-grub
+++ b/meta-resin-common/recipes-support/hostapp-update-hooks/files/99-resin-grub
@@ -15,11 +15,11 @@ else
 fi
 
 new_part=$(findmnt --noheadings --canonicalize --output SOURCE $SYSROOT)
-new_part_label=$(blkid "$new_part" | awk '{print $2}')
+new_part_label=$(blkid "$new_part" | awk '{print $2}' | cut -d'"' -f 2)
 
 printf "[INFO] Switching root partition to %s..." "$new_part_label..."
 grub_cfg=$(find /mnt/boot/ -name grub.cfg)
-sed "s/root=[^ ]* /"root=$new_part_label" /" "$grub_cfg" > "$grub_cfg".new
+sed "s/resin-root./"$new_part_label"/" "$grub_cfg" > "$grub_cfg".new
 
 sync -f $(dirname "$grub_cfg")
 mv "$grub_cfg".new "$grub_cfg"


### PR DESCRIPTION
Change-type: minor
Changelog-entry: Add support for aufs 4.14.56+
Signed-off-by: Florin Sarbu <florin@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
