### PR TITLE
Move kernel from image recipe to packagegroup

### DIFF
--- a/meta-resin-common/recipes-core/images/resin-image.bb
+++ b/meta-resin-common/recipes-core/images/resin-image.bb
@@ -34,7 +34,6 @@ IMAGE_INSTALL = " \
     packagegroup-resin-debugtools \
     packagegroup-resin-connectivity \
     packagegroup-resin \
-    kernel-image-initramfs \
     "
 
 generate_rootfs_fingerprints () {

--- a/meta-resin-common/recipes-core/packagegroups/packagegroup-resin.inc
+++ b/meta-resin-common/recipes-core/packagegroups/packagegroup-resin.inc
@@ -15,6 +15,7 @@ RDEPENDS_${PN} = " \
     resin-extra-udev-rules \
     rsync \
     kernel-modules \
+    kernel-image-initramfs \
     os-config \
     os-release \
     less \


### PR DESCRIPTION
The kernel was included in the rootfs in v2.18. But didn't reach the rootfs in the flasher images.

Tested on resin-intel in a VM.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
