### PR TITLE
kernel-resin.bbclass: Add required mbim and qmi configs

### DIFF
--- a/meta-resin-common/classes/kernel-resin.bbclass
+++ b/meta-resin-common/classes/kernel-resin.bbclass
@@ -354,11 +354,21 @@ RESIN_CONFIGS_DEPS[governor] ?= " \
     "
 
 # support for mbim cell modems
+RESIN_CONFIGS_DEPS[mbim] = " \
+    CONFIG_USB_NET_DRIVERS=m \
+    CONFIG_USB_USBNET=m \
+"
+
 RESIN_CONFIGS[mbim] = " \
     CONFIG_USB_NET_CDC_MBIM=m \
     "
 
 # support for qmi cell modems
+RESIN_CONFIGS_DEPS[qmi] = " \
+    CONFIG_USB_NET_DRIVERS=m \
+    CONFIG_USB_USBNET=m \
+"
+
 RESIN_CONFIGS[qmi] = " \
     CONFIG_USB_NET_QMI_WWAN=m \
     "


### PR DESCRIPTION
MBIM and QMI support needs USB_NET_DRIVERS and USB_USBNET enabled.

Changelog-entry: Enable kernel config dependencies for MBIM and QMI
Signed-off-by: Florin Sarbu <florin@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
