### PR TITLE
Remove wl12xx firmware

### DIFF
--- a/meta-resin-krogoth/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
+++ b/meta-resin-krogoth/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
@@ -16,5 +16,4 @@ CONNECTIVITY_FIRMWARES_append = " \
     linux-firmware-iwlwifi-7265d \
     linux-firmware-iwlwifi-8000c \
     linux-firmware-rtl8188eu \
-    linux-firmware-wl12xx \
     "

--- a/meta-resin-morty/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
+++ b/meta-resin-morty/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
@@ -17,5 +17,4 @@ CONNECTIVITY_FIRMWARES_append = " \
     linux-firmware-iwlwifi-8000c \
     linux-firmware-iwlwifi-8265 \
     linux-firmware-rtl8188eu \
-    linux-firmware-wl12xx \
     "

--- a/meta-resin-pyro/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
+++ b/meta-resin-pyro/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
@@ -17,5 +17,4 @@ CONNECTIVITY_FIRMWARES_append = " \
     linux-firmware-iwlwifi-8000c \
     linux-firmware-iwlwifi-8265 \
     linux-firmware-rtl8188eu \
-    linux-firmware-wl12xx \
     "

--- a/meta-resin-rocko/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
+++ b/meta-resin-rocko/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
@@ -17,5 +17,4 @@ CONNECTIVITY_FIRMWARES_append = " \
     linux-firmware-iwlwifi-8000c \
     linux-firmware-iwlwifi-8265 \
     linux-firmware-rtl8188eu \
-    linux-firmware-wl12xx \
     "

--- a/meta-resin-sumo/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
+++ b/meta-resin-sumo/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
@@ -17,5 +17,4 @@ CONNECTIVITY_FIRMWARES_append = " \
     linux-firmware-iwlwifi-8000c \
     linux-firmware-iwlwifi-8265 \
     linux-firmware-rtl8188eu \
-    linux-firmware-wl12xx \
     "


### PR DESCRIPTION
Tested on nuc image. Frees up 5 mb in the dev image.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
