### PR TITLE
aufs-util: Package auplink separately

### DIFF
--- a/meta-resin-common/recipes-core/packagegroups/packagegroup-resin.bb
+++ b/meta-resin-common/recipes-core/packagegroups/packagegroup-resin.bb
@@ -25,6 +25,6 @@ RDEPENDS_${PN} += " \
     resin-device-progress \
     balena-rollback \
     timeinit \
-    ${@bb.utils.contains('BALENA_STORAGE', 'aufs', 'aufs-util', '', d)} \
+    ${@bb.utils.contains('BALENA_STORAGE', 'aufs', 'aufs-util-auplink', '', d)} \
     ${RESIN_SUPERVISOR} \
     "

--- a/meta-resin-common/recipes-utils/aufs-util/aufs-util_%.bbappend
+++ b/meta-resin-common/recipes-utils/aufs-util/aufs-util_%.bbappend
@@ -1,0 +1,3 @@
+PACKAGES =+ "${PN}-auplink"
+
+FILES_${PN}-auplink = "/sbin/auplink"


### PR DESCRIPTION
From the aufs-util package only the auplink binary is needed and that
dependency is from balena. So we package auplink in a separate package
and just install that package into the rootfs.

Change-type: minor
Chanelog-entry: Only add auplink binary into the rootfs to decrease rootfs size
Signed-off-by: Florin Sarbu <florin@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
