### PR TITLE
Replace NM's DHCP request option "Client indentifier"

### DIFF
--- a/meta-resin-common/recipes-connectivity/networkmanager/networkmanager/balena-client-id.patch
+++ b/meta-resin-common/recipes-connectivity/networkmanager/networkmanager/balena-client-id.patch
@@ -1,0 +1,39 @@
+From dfe53c829e24f1240a2ac8ef8819b506c7d22cfc Mon Sep 17 00:00:00 2001
+From: Sebastian Panceac <sebastian@resin.io>
+Date: Wed, 17 Oct 2018 14:36:56 +0200
+Subject: Replace NM's DHCP request option "Client indentifier" with udhcpc style option
+
+Signed-off-by: Sebastian Panceac <sebastian@balena.io>
+
+Upstream-Status: Pending
+---
+ src/systemd/src/libsystemd-network/sd-dhcp-client.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/systemd/src/libsystemd-network/sd-dhcp-client.c b/src/systemd/src/libsystemd-network/sd-dhcp-client.c
+index c2f81e1..16962db 100644
+--- a/src/systemd/src/libsystemd-network/sd-dhcp-client.c
++++ b/src/systemd/src/libsystemd-network/sd-dhcp-client.c
+@@ -627,13 +627,17 @@ static int client_message_init(
+                 client->client_id_len = sizeof(client->client_id.type) + sizeof(client->client_id.ns.iaid) + duid_len;
+         }
+ 
++        uint8_t balena_client_id[7] = {0};
++        balena_client_id[0] = 1; /* Hardware type: Ethernet */
++        memcpy(balena_client_id + 1, client->mac_addr, 6); /* MAC addr */
++
+         /* Some DHCP servers will refuse to issue an DHCP lease if the Client
+            Identifier option is not set */
+         if (client->client_id_len) {
+                 r = dhcp_option_append(&packet->dhcp, optlen, &optoffset, 0,
+                                        SD_DHCP_OPTION_CLIENT_IDENTIFIER,
+-                                       client->client_id_len,
+-                                       &client->client_id);
++                                       sizeof(balena_client_id),
++                                       balena_client_id);
+                 if (r < 0)
+                         return r;
+         }
+-- 
+2.7.4
+

--- a/meta-resin-common/recipes-connectivity/networkmanager/networkmanager_1.12.2.bb
+++ b/meta-resin-common/recipes-connectivity/networkmanager/networkmanager_1.12.2.bb
@@ -31,6 +31,7 @@ SRC_URI = " \
     file://0001-sd-lldp.h-Remove-net-ethernet.h-seems-to-be-over-spe.patch \
     file://0002-Fixed-configure.ac-Fix-pkgconfig-sysroot-locations.patch \
     file://0003-Do-not-create-settings-settings-property-documentati.patch \
+    file://balena-client-id.patch \
 "
 SRC_URI[md5sum] = "94d02b80b120f166927e6ef242b29a9b"
 SRC_URI[sha256sum] = "6be06ff93a05f3ee4da9e58e4a0d974eef245c08b6f02b00a9e44154c9801a26"


### PR DESCRIPTION
This patch replaces the "Client identifier" option from
DHCP packets sent by NM to resemble the way udhcpc does it.

The reason is that the Cisco RV325 router with fw older than
v1.2.1.14 doesn't reply to DHCP requests or discovery packages
if the "Client identifier" option is formatted in NM's style.

Even though this is a bug in the router's fw, we are going to
fix it here because we encountered clients that couldn't get
an IP address on these routers and we want to avoid that

Change-type: patch
Changelog-entry: Replace NM's DHCP request option "Client indentifier" with udhcpc style option
Signed-off-by: Sebastian Panceac <sebastian@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
