### PR TITLE
Avoid expander on flasher based on root kernel argument

### DIFF
--- a/meta-resin-common/recipes-core/initrdscripts/files/resindataexpander
+++ b/meta-resin-common/recipes-core/initrdscripts/files/resindataexpander
@@ -6,9 +6,22 @@ datadev=$(lsblk $datapart -n -o PKNAME)
 
 resindataexpander_enabled() {
     # On flasher avoid expanding partition
-    if [ -h /dev/disk/by-label/flash-boot ]; then
-        echo "[INFO] Flasher detected. Avoiding expand partition mechanism."
-        return 1
+	if [ -h /dev/disk/by-label/flash-rootA ]; then
+		flash_root=$(readlink -f "/dev/disk/by-label/flash-rootA")
+		if [ "`echo ${bootparam_root} | cut -c1-5`" = "UUID=" ]; then
+			root_uuid=`echo $bootparam_root | cut -c6-`
+			root_link="/dev/disk/by-uuid/$root_uuid"
+		elif [ "`echo ${bootparam_root} | cut -c1-9`" = "PARTUUID=" ]; then
+			root_puuid=`echo $bootparam_root | cut -c10-`
+			root_link="/dev/disk/by-partuuid/$root_puuid"
+		elif [ "`echo ${bootparam_root} | cut -c1-6`" = "LABEL=" ]; then
+			root_label=`echo $bootparam_root | cut -c7-`
+			root_link="/dev/disk/by-label/$root_link"
+		fi
+		if [ "$(readlink -f "$root_link")" == "$flash-root" ]; then
+			echo "[INFO] Flasher detected. Avoiding expand partition mechanism."
+			return 1
+		fi
     fi
 
     for freespace in $(parted -m /dev/$datadev unit MiB print free | grep free | cut -d: -f4 | sed 's/MiB//g'); do


### PR DESCRIPTION
The current implementation checks for the existence of the `flash-boot`
label. This breaks when after flashing the flashing device is left
plugged. Change this with a check based on the root kernel argument.

Fixes #1210

Change-type: minor
Changelog-entry: Avoid expander on flasher based on root kernel argument
Signed-off-by: Andrei Gherzan <andrei@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
